### PR TITLE
fix: Dev release tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,8 +159,8 @@ jobs:
 
       - name: Set DEV release version
         run: |
-          poetry install --with build -n
-          poetry run semantic-release version --no-commit --no-vcs-release --no-changelog --no-push
+          poetry version $(poetry run semantic-release version --print)-dev.${{ github.run_id }}
+          poetry version -s
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Fixes DEV release tag to be `<next prod release version>-dev.<build number>`