### PR TITLE
test: resourceaccess integration testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,7 @@ jobs:
         TWINGATE_HOST: ${{ secrets.TWINGATE_HOST }}
         TWINGATE_NETWORK: ${{ secrets.TWINGATE_NETWORK }}
         TWINGATE_REMOTE_NETWORK_ID: ${{ secrets.TWINGATE_REMOTE_NETWORK_ID }}
+        TWINGATE_TEST_PRINCIPAL_ID: ${{ secrets.TWINGATE_TEST_PRINCIPAL_ID }}
 
   build:
     runs-on: ubuntu-latest

--- a/tests_integration/test_main.py
+++ b/tests_integration/test_main.py
@@ -577,7 +577,7 @@ def test_resource_access_flows(kopf_settings, unique_resource_name):
     # fmt: off
     with KopfRunner(kopf_runner_args, settings=kopf_settings) as runner:
         kubectl_create(RESOURCE_OBJ)
-        time.sleep(5)  # give it some time to react
+        time.sleep(10)  # give it some time to react
 
         kubectl_create(OBJ)
         time.sleep(5)  # give it some time to react

--- a/tests_integration/test_main.py
+++ b/tests_integration/test_main.py
@@ -119,8 +119,6 @@ def test_resource_flows(kopf_settings, unique_resource_name):
     assert runner.exit_code == 0
 
     logs = load_stdout(runner.stdout)
-    for log in logs:
-        print(log)
 
     # fmt: off
 
@@ -549,8 +547,8 @@ class TestResourceCRD:
 
 @pytest.mark.integration()
 def test_resource_access_flows(kopf_settings, unique_resource_name):
-    assert "TWINGATE_PRINCIPAL_ID" in os.environ
-    principal_id = os.environ["TWINGATE_PRINCIPAL_ID"]
+    assert "TWINGATE_TEST_PRINCIPAL_ID" in os.environ
+    principal_id = os.environ["TWINGATE_TEST_PRINCIPAL_ID"]
 
     RESOURCE_OBJ = f"""
         apiVersion: twingate.com/v1beta
@@ -597,8 +595,6 @@ def test_resource_access_flows(kopf_settings, unique_resource_name):
     assert runner.exit_code == 0
 
     logs = load_stdout(runner.stdout)
-    for log in logs:
-        print(log)
 
 
     # Create

--- a/tests_integration/test_main.py
+++ b/tests_integration/test_main.py
@@ -572,6 +572,7 @@ def test_resource_access_flows(kopf_settings, unique_resource_name):
 
     # fmt: off
     with KopfRunner(kopf_runner_args, settings=kopf_settings) as runner:
+        time.sleep(5) # give it some time to react
         kubectl_create(RESOURCE_OBJ)
         time.sleep(10)  # give it some time to react
 

--- a/tests_integration/test_main.py
+++ b/tests_integration/test_main.py
@@ -240,9 +240,8 @@ def test_resource_access_flows(kopf_settings, unique_resource_name):
 
     # fmt: off
     with KopfRunner(kopf_runner_args, settings=kopf_settings) as runner:
-        time.sleep(5) # give it some time to react
         kubectl_create(RESOURCE_OBJ)
-        time.sleep(10)  # give it some time to react
+        time.sleep(5)  # give it some time to react
 
         kubectl_create(OBJ)
         time.sleep(5)  # give it some time to react

--- a/tests_integration/test_main.py
+++ b/tests_integration/test_main.py
@@ -8,11 +8,9 @@ import kopf
 import orjson as json
 import pytest
 from kopf.testing import KopfRunner
-import pydevd_pycharm
 
 
 # ruff: noqa: S602 (subprocess_popen_with_shell_equals_true)
-# pydevd_pycharm.settrace('192.168.50.224', port=3192, stdoutToServer=True, stderrToServer=True)
 
 
 main_py = os.path.relpath(os.path.join(os.path.dirname(__file__), "../main.py"))
@@ -78,7 +76,7 @@ def _load_crds():
     kubectl("apply -f ./deploy/twingate-operator/crds/")
 
 
-# @pytest.mark.integration()
+@pytest.mark.integration()
 def test_resource_flows(kopf_settings, unique_resource_name):
     OBJ = f"""
         apiVersion: twingate.com/v1beta
@@ -156,7 +154,7 @@ def test_resource_flows(kopf_settings, unique_resource_name):
     # fmt: on
 
 
-# @pytest.mark.integration()
+@pytest.mark.integration()
 def test_resource_created_before_operator_runs(kopf_settings, unique_resource_name):
     OBJ = f"""
         apiVersion: twingate.com/v1beta
@@ -217,7 +215,7 @@ def test_resource_created_before_operator_runs(kopf_settings, unique_resource_na
     # fmt: on
 
 
-# @pytest.mark.integration()
+@pytest.mark.integration()
 class TestResourceCRD:
     def test_browser_shortcut_false_allows_wildcard_address(self, unique_resource_name):
         result = kubectl_create(

--- a/tests_integration/test_main.py
+++ b/tests_integration/test_main.py
@@ -323,7 +323,6 @@ class TestResourceCRD:
         )
 
         assert result.returncode == 0
-        kubectl(f"delete tgr/{unique_resource_name}")
 
     def test_browser_shortcut_cant_have_wildcard_address(self, unique_resource_name):
         with pytest.raises(subprocess.CalledProcessError) as ex:
@@ -408,7 +407,6 @@ class TestResourceCRD:
         )
 
         assert result.returncode == 0, result.value.stderr.decode()
-        kubectl(f"delete tgr/{unique_resource_name}")
 
     def test_protocols_udp_allowall_cant_specify_ports(self, unique_resource_name):
         with pytest.raises(subprocess.CalledProcessError) as ex:

--- a/tests_integration/test_main.py
+++ b/tests_integration/test_main.py
@@ -615,4 +615,3 @@ def test_resource_access_flows(kopf_settings, unique_resource_name):
 
     # Shutdown
     assert {"message": "Activity 'shutdown' succeeded.", "timestamp": ANY, "severity": "info"} in logs
-

--- a/tests_integration/test_main.py
+++ b/tests_integration/test_main.py
@@ -323,6 +323,7 @@ class TestResourceCRD:
         )
 
         assert result.returncode == 0
+        kubectl(f"delete tgr/{unique_resource_name}")
 
     def test_browser_shortcut_cant_have_wildcard_address(self, unique_resource_name):
         with pytest.raises(subprocess.CalledProcessError) as ex:
@@ -407,6 +408,7 @@ class TestResourceCRD:
         )
 
         assert result.returncode == 0, result.value.stderr.decode()
+        kubectl(f"delete tgr/{unique_resource_name}")
 
     def test_protocols_udp_allowall_cant_specify_ports(self, unique_resource_name):
         with pytest.raises(subprocess.CalledProcessError) as ex:

--- a/tests_integration/test_main.py
+++ b/tests_integration/test_main.py
@@ -9,7 +9,6 @@ import orjson as json
 import pytest
 from kopf.testing import KopfRunner
 
-
 # ruff: noqa: S602 (subprocess_popen_with_shell_equals_true)
 
 
@@ -560,7 +559,6 @@ def test_resource_access_flows(kopf_settings, unique_resource_name):
           address: my.default.cluster.local
     """
 
-
     OBJ = f"""
         apiVersion: twingate.com/v1beta
         kind: TwingateResourceAccess
@@ -580,13 +578,13 @@ def test_resource_access_flows(kopf_settings, unique_resource_name):
         kubectl_create(OBJ)
         time.sleep(5)  # give it some time to react
 
-        created_object = json.loads(kubectl(f"get tgra/{unique_resource_name} -o json").stdout)
+        json.loads(kubectl(f"get tgra/{unique_resource_name} -o json").stdout)
 
         delete_command = kubectl(f"delete tgra/{unique_resource_name}")
 
         time.sleep(1)  # give it some time to react
 
-        resource_delete_command = kubectl(f"delete tgr/{unique_resource_name}")
+        kubectl(f"delete tgr/{unique_resource_name}")
 
     # fmt: on
 
@@ -596,18 +594,45 @@ def test_resource_access_flows(kopf_settings, unique_resource_name):
 
     logs = load_stdout(runner.stdout)
 
-
     # Create
-    assert {"message": "Handler 'twingate_resource_access_create' succeeded.", "timestamp": ANY,
-            "object": {"apiVersion": "twingate.com/v1beta", "kind": "TwingateResourceAccess", "name": unique_resource_name,
-                       "uid": ANY, "namespace": "default"}, "severity": "info"} in logs
+    assert {
+        "message": "Handler 'twingate_resource_access_create' succeeded.",
+        "timestamp": ANY,
+        "object": {
+            "apiVersion": "twingate.com/v1beta",
+            "kind": "TwingateResourceAccess",
+            "name": unique_resource_name,
+            "uid": ANY,
+            "namespace": "default",
+        },
+        "severity": "info",
+    } in logs
     # Delete
-    assert {"message": "Result: {'resourceAccessRemove': {'ok': True, 'error': None}}", "timestamp": ANY,
-            "severity": "info"} in logs
-    assert {"message": "Handler 'twingate_resource_access_delete' succeeded.", "timestamp": ANY,
-            "object": {"apiVersion": "twingate.com/v1beta", "kind": "TwingateResourceAccess", "name": unique_resource_name,
-                       "uid": ANY, "namespace": "default"}, "severity": "info"} in logs
-    assert delete_command.stdout.decode() == f'twingateresourceaccess.twingate.com "{unique_resource_name}" deleted\n'
+    assert {
+        "message": "Result: {'resourceAccessRemove': {'ok': True, 'error': None}}",
+        "timestamp": ANY,
+        "severity": "info",
+    } in logs
+    assert {
+        "message": "Handler 'twingate_resource_access_delete' succeeded.",
+        "timestamp": ANY,
+        "object": {
+            "apiVersion": "twingate.com/v1beta",
+            "kind": "TwingateResourceAccess",
+            "name": unique_resource_name,
+            "uid": ANY,
+            "namespace": "default",
+        },
+        "severity": "info",
+    } in logs
+    assert (
+        delete_command.stdout.decode()
+        == f'twingateresourceaccess.twingate.com "{unique_resource_name}" deleted\n'
+    )
 
     # Shutdown
-    assert {"message": "Activity 'shutdown' succeeded.", "timestamp": ANY, "severity": "info"} in logs
+    assert {
+        "message": "Activity 'shutdown' succeeded.",
+        "timestamp": ANY,
+        "severity": "info",
+    } in logs


### PR DESCRIPTION
## Related Tickets & Documents

- Issue:
Adding integration test for resource access flow

## Changes
Adding integration test for resource access flow

## Notes
1. Added environmental variable "TWINGATE_TEST_PRINCIPAL_ID" as requirement for testing as resourceAccess requires the value
2. Added environtal variable "TWINGATE_REMOTE_NETWORK_ID" as requirement for testing as this is required by the operator
