### PR TITLE
fix: chore, build changes should change patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,3 +162,19 @@ prerelease = false
 exclude_commit_patterns = [
     "Bumps*"
 ]
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = [
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "style",
+    "refactor",
+    "test",
+]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf", "chore", "build"]


### PR DESCRIPTION
## Related Tickets & Documents

- Issue:

## Changes
- Added setting that tells `semantic-release` to patch when seeing `chore` or `build` commits:
```
patch_tags = ["fix", "perf", "chore", "build"]
```

Say we release a version `1.0.0` and now dependabot merges a dependency update (`chore` PR) it should be released 
as `1.0.1-dev.<build>` because its newer than `1.0.0`.
Today it gets released as `1.0.0-dev.<build>` which is considered older than `1.0.0`

