### PR TITLE
feat: Allow customizing connector logLevel

### DIFF
--- a/app/crds.py
+++ b/app/crds.py
@@ -282,6 +282,7 @@ class ConnectorSpec(BaseModel):
 
     id: str | None = None
     name: str | None = None
+    log_level: int = 3
     image: ConnectorImage | None = None
     image_policy: ConnectorImagePolicy | None = None
     container_extra: dict[str, Any] = {}

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -13,7 +13,7 @@ ANNOTATION_NEXT_VERSION_CHECK = "twingate.com/next-version-check"
 
 
 def get_connector_pod(
-    crd: TwingateConnectorCRD, tenant_url: str, image: str, log_level: int = 7
+    crd: TwingateConnectorCRD, tenant_url: str, image: str
 ) -> kubernetes.client.V1Pod:
     spec = crd.spec
     name = crd.metadata.name
@@ -39,7 +39,7 @@ def get_connector_pod(
                     {"name": "TWINGATE_LABEL_DEPLOYED_BY", "value": "operator"},
                     {"name": "TWINGATE_LABEL_OPERATOR_VERSION", "value": get_version()},
                     {"name": "TWINGATE_URL", "value": tenant_url},
-                    {"name": "TWINGATE_LOG_LEVEL", "value": str(log_level)},
+                    {"name": "TWINGATE_LOG_LEVEL", "value": str(spec.log_level)},
                 ]+env_labels_version_policy,
                 "envFrom": [
                     {

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -36,6 +36,12 @@ spec:
                   nullable: false
                   maxLength: 30
                   description: "Name of the Connector (optional, if not specified Twingate will give a random name)"
+                logLevel:
+                  type: integer
+                  default: 3
+                  minimum: -1
+                  maximum: 7
+                  description: "Log level for the Connector (-1 to 7: -1 for no logs, 0 - least verbose, 7 - most verbose, default: 3)."
                 image:
                   type: object
                   description: "Image defines the image to use for the Connector."

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -17,6 +17,7 @@ def test_connector_flows(kopf_settings, kopf_runner_args, ci_run_number):
             name: {connector_name}
         spec:
             name: {connector_name}
+            logLevel: 7
             imagePolicy:
                 provider: "dockerhub"
                 schedule: "* * * * *"
@@ -48,6 +49,10 @@ def test_connector_flows(kopf_settings, kopf_runner_args, ci_run_number):
         assert pod["metadata"]["labels"]["twingate.com/connector"] == connector_name
         assert pod["metadata"]["ownerReferences"][0]["name"] == connector_name
         assert pod["metadata"]["ownerReferences"][0]["kind"] == "TwingateConnector"
+
+        container = pod["spec"]["containers"][0]
+        container_env = {t["name"]: t["value"] for t in container["env"]}
+        assert container_env["TWINGATE_LOG_LEVEL"] == "7"
 
         # Check that if pod is deleted we recreate it
         kubectl_delete(f"pod/{connector_name}")

--- a/tests_integration/test_crds_connector.py
+++ b/tests_integration/test_crds_connector.py
@@ -68,6 +68,22 @@ class TestConnectorCRD:
         )
 
         assert result.returncode == 0
+
+        data = kubectl_get("tc", unique_connector_name)
+        assert data == {
+            "apiVersion": "twingate.com/v1beta",
+            "kind": "TwingateConnector",
+            "metadata": {
+                "creationTimestamp": ANY,
+                "generation": 1,
+                "name": unique_connector_name,
+                "namespace": "default",
+                "resourceVersion": ANY,
+                "uid": ANY,
+            },
+            "spec": {"logLevel": 4, "name": unique_connector_name},
+        }
+
         kubectl_delete(f"tc/{unique_connector_name}")
 
     def test_loglevel_too_high(self, unique_connector_name):
@@ -139,6 +155,7 @@ class TestConnectorCRD:
             },
             "spec": {
                 "image": {"repository": "twingate/connector", "tag": "latest"},
+                "logLevel": 3,
                 "name": unique_connector_name,
             },
         }
@@ -181,6 +198,7 @@ class TestConnectorCRD:
                     "allowPrerelease": False,
                 },
                 "name": unique_connector_name,
+                "logLevel": 3,
             },
         }
 


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #57 

## Changes

Allow customizing `logLevel` via the `TwingateConnector` CRD spec.

- Modified CRD
- Modified CRD Python model
- Modified `get_connector_pod`

