### PR TITLE
fix: gql.Client can't be singleton as its not thread-safe

### DIFF
--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import kopf
 
-from app.api.client import GraphQLMutationError
+from app.api.client import GraphQLMutationError, TwingateAPIClient
 from app.crds import ResourceAccessSpec
 from app.handlers.base import fail, success
 
@@ -26,7 +26,8 @@ def twingate_resource_access_create(body, spec, memo, logger, patch, **kwargs):
         raise kopf.TemporaryError("Resource not yet created, retrying...", delay=15)
 
     try:
-        memo.twingate_client.resource_access_add(
+        client = TwingateAPIClient(memo.twingate_settings)
+        client.resource_access_add(
             spec.id, access_crd.principal_id, access_crd.security_policy_id
         )
         kopf.info(
@@ -63,7 +64,8 @@ def twingate_resource_access_update(new, diff, status, memo, logger, **kwargs):
     access_crd = ResourceAccessSpec(**new["spec"])
     if resource_crd := access_crd.get_resource():
         try:
-            memo.twingate_client.resource_access_add(
+            client = TwingateAPIClient(memo.twingate_settings)
+            client.resource_access_add(
                 resource_crd.spec.id,
                 access_crd.principal_id,
                 access_crd.security_policy_id,
@@ -81,9 +83,8 @@ def twingate_resource_access_delete(spec, status, memo, logger, **kwargs):
     access_crd = ResourceAccessSpec(**spec)
     resource_crd = access_crd.get_resource()
     if resource_id := resource_crd and resource_crd.spec.id:
-        memo.twingate_client.resource_access_remove(
-            resource_id, access_crd.principal_id
-        )
+        client = TwingateAPIClient(memo.twingate_settings)
+        client.resource_access_remove(resource_id, access_crd.principal_id)
 
 
 @kopf.timer(
@@ -105,7 +106,8 @@ def twingate_resource_access_sync(body, spec, status, memo, logger, **kwargs):
         return success(status="Skipped as resource not yet created")
 
     try:
-        memo.twingate_client.resource_access_add(
+        client = TwingateAPIClient(memo.twingate_settings)
+        client.resource_access_add(
             resource_crd.spec.id, access_crd.principal_id, access_crd.security_policy_id
         )
         return success()

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -301,11 +301,11 @@ def test_twingate_connector_delete_ignores_k8s_api_errors(
 
 
 def test_twingate_connector_delete_without_status_does_nothing(
-    get_connector_and_crd, kopf_handler_runner
+    get_connector_and_crd, kopf_handler_runner, mock_api_client
 ):
     connector, crd = get_connector_and_crd()
-    run = kopf_handler_runner(twingate_connector_delete, crd, MagicMock())
-    run.memo_mock.twingate_client.connector_delete.assert_not_called()
+    kopf_handler_runner(twingate_connector_delete, crd, MagicMock())
+    mock_api_client.connector_delete.assert_not_called()
 
 
 def test_twingate_connector_pod_deleted_tags_owner(get_connector_and_crd):

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -68,15 +68,16 @@ class TestResourceAccessCreateHandler:
             }
         ]
 
-    def test_create_invalid_ref(self):
+    def test_create_invalid_ref(self, mock_api_client):
         resource_access_spec = {
             "resourceRef": {"name": "invalid"},
             "principalId": "R3JvdXA6MTE1NzI2MA==",
         }
 
+        mock_api_client.resource_access_add.return_value = True
+
         logger_mock = MagicMock()
         memo_mock = MagicMock()
-        memo_mock.twingate_client.resource_access_add.return_value = True
         patch_mock = MagicMock()
 
         with patch(
@@ -102,7 +103,7 @@ class TestResourceAccessCreateHandler:
                 message="Resource default/invalid not found",
             )
 
-    def test_create_resource_no_id(self, resource_factory):
+    def test_create_resource_no_id(self, resource_factory, mock_api_client):
         resource = resource_factory()
         resource_spec = resource.to_spec(id=None)
 
@@ -111,9 +112,10 @@ class TestResourceAccessCreateHandler:
             "principalId": "R3JvdXA6MTE1NzI2MA==",
         }
 
+        mock_api_client.resource_access_add.return_value = True
+
         logger_mock = MagicMock()
         memo_mock = MagicMock()
-        memo_mock.twingate_client.resource_access_add.return_value = True
         patch_mock = MagicMock()
 
         resource_crd_mock = MagicMock()
@@ -175,7 +177,7 @@ class TestResourceAccessCreateHandler:
 
 
 class TestResourceAccessUpdateHandler:
-    def test_update_success(self, resource_factory):
+    def test_update_success(self, resource_factory, mock_api_client):
         resource = resource_factory()
         resource_spec = resource.to_spec()
 
@@ -187,7 +189,8 @@ class TestResourceAccessUpdateHandler:
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
-        memo_mock.twingate_client.resource_access_add.return_value = True
+
+        mock_api_client.resource_access_add.return_value = True
 
         resource_crd_mock = MagicMock()
         resource_crd_mock.spec = resource_spec
@@ -206,7 +209,7 @@ class TestResourceAccessUpdateHandler:
             )
             assert result == {"success": True, "ts": ANY}
 
-    def test_update_fails_to_find_resource(self):
+    def test_update_fails_to_find_resource(self, mock_api_client):
         resource_access_spec = {
             "resourceRef": {"name": "doesnt-exist"},
             "principalId": "R3JvdXA6MTE1NzI2MA==",
@@ -215,7 +218,8 @@ class TestResourceAccessUpdateHandler:
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
-        memo_mock.twingate_client.resource_access_add.return_value = True
+
+        mock_api_client.resource_access_add.return_value = True
 
         with patch(
             "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
@@ -250,7 +254,7 @@ class TestResourceAccessUpdateHandler:
 
 
 class TestResourceAccessDelete:
-    def test_delete_success(self, resource_factory):
+    def test_delete_success(self, resource_factory, mock_api_client):
         resource = resource_factory()
         resource_spec = resource.to_spec()
 
@@ -261,7 +265,8 @@ class TestResourceAccessDelete:
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
-        memo_mock.twingate_client.resource_access_remove.return_value = True
+
+        mock_api_client.resource_access_remove.return_value = True
 
         resource_crd_mock = MagicMock()
         resource_crd_mock.spec = resource_spec
@@ -275,7 +280,7 @@ class TestResourceAccessDelete:
                 resource_access_spec, {}, memo_mock, logger_mock
             )
 
-    def test_delete_resource_doesnt_exist_does_nothing(self):
+    def test_delete_resource_doesnt_exist_does_nothing(self, mock_api_client):
         resource_access_spec = {
             "resourceRef": {"name": "doesnt-exist"},
             "principalId": "R3JvdXA6MTE1NzI2MA==",
@@ -292,11 +297,11 @@ class TestResourceAccessDelete:
                 resource_access_spec, {}, memo_mock, logger_mock
             )
 
-        memo_mock.twingate_client.resource_access_remove.assert_not_called()
+        mock_api_client.resource_access_remove.assert_not_called()
 
 
 class TestResourceAccessSync:
-    def test_sync_success(self, resource_factory):
+    def test_sync_success(self, resource_factory, mock_api_client):
         resource = resource_factory()
         resource_spec = resource.to_spec()
 
@@ -307,7 +312,8 @@ class TestResourceAccessSync:
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
-        memo_mock.twingate_client.resource_access_add.return_value = True
+
+        mock_api_client.resource_access_add.return_value = True
 
         resource_crd_mock = MagicMock()
         resource_crd_mock.spec = resource_spec
@@ -327,7 +333,7 @@ class TestResourceAccessSync:
 
             assert result == {"success": True, "ts": ANY}
 
-    def test_sync_api_fails(self, resource_factory):
+    def test_sync_api_fails(self, resource_factory, mock_api_client):
         resource = resource_factory()
         resource_spec = resource.to_spec()
 
@@ -338,8 +344,9 @@ class TestResourceAccessSync:
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
-        memo_mock.twingate_client.resource_access_add.side_effect = (
-            GraphQLMutationError("resourceAccessAdd", "some error")
+
+        mock_api_client.resource_access_add.side_effect = GraphQLMutationError(
+            "resourceAccessAdd", "some error"
         )
 
         resource_crd_mock = MagicMock()

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -369,7 +369,9 @@ class TestResourceAccessSync:
 
         kopf_exception_mock.assert_called_once_with("", reason="Failure", message=ANY)
 
-    def test_sync_resource_not_found_should_warn(self, resource_factory):
+    def test_sync_resource_not_found_should_warn(
+        self, resource_factory, mock_api_client
+    ):
         resource = resource_factory()
         resource.to_spec()
 
@@ -380,7 +382,8 @@ class TestResourceAccessSync:
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
-        memo_mock.twingate_client.get_resource.return_value = None
+
+        mock_api_client.get_resource.return_value = None
 
         expected_err = "Resource default/impossible not found"
 
@@ -401,7 +404,9 @@ class TestResourceAccessSync:
             "", reason="ResourceNotFound", message=expected_err
         )
 
-    def test_sync_resource_spec_missing_id_should_skip(self, resource_factory):
+    def test_sync_resource_spec_missing_id_should_skip(
+        self, resource_factory, mock_api_client
+    ):
         resource = resource_factory()
         resource_spec = resource.to_spec(id=None)
 
@@ -412,7 +417,8 @@ class TestResourceAccessSync:
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
-        memo_mock.twingate_client.get_resource.return_value = resource
+
+        mock_api_client.get_resource.return_value = resource
 
         resource_crd_mock = MagicMock()
         resource_crd_mock.spec = resource_spec

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ from typing import Any
 import kopf
 from pydantic import ValidationError
 
-from app.api import TwingateAPIClient
 from app.handlers import *  # noqa: F403
 from app.settings import TwingateOperatorSettings
 
@@ -29,7 +28,7 @@ def startup(
     settings: kopf.OperatorSettings,
     logger: logging.Logger | logging.LoggerAdapter,
     memo: Any,
-    **kwargs
+    **kwargs,
 ):
     logger.info("Operator is starting up...")
 
@@ -39,7 +38,6 @@ def startup(
 
     try:
         memo.twingate_settings = TwingateOperatorSettings()
-        memo.twingate_client = TwingateAPIClient(memo.twingate_settings)
     except ValidationError:
         logger.exception("Failed to load settings.")
 


### PR DESCRIPTION
## Changes

`gql.Client` is not thread-safe so we cant use it as singleton

https://github.com/graphql-python/gql/issues/314
