### PR TITLE
feat: Add relevant security context to run as non root

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -54,7 +54,12 @@ def get_connector_pod(
                 "imagePullPolicy": "Always",
                 "name": "connector",
                 "securityContext": {
-                    "allowPrivilegeEscalation": False
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {
+                        "drop": ["ALL"],
+                    },
+                    "runAsNonRoot": True,
+                    "runAsUser": 65532,
                },
                 **spec.container_extra,
             }


### PR DESCRIPTION
## Related Tickets & Documents

Resolves #102 

## Changes

Add relevant `securityContext` settings to run connector `0.163.0` as non root and allow running under restricted pod security policy.

