### PR TITLE
fix: Fix resource `protocols` diffing and serialization

### DIFF
--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -40,8 +40,8 @@ class ResourceProtocol(BaseModel):
         frozen=True, populate_by_name=True, alias_generator=to_camel
     )
 
-    policy: ProtocolPolicy
-    ports: list[ProtocoRange] | None = None
+    policy: ProtocolPolicy = ProtocolPolicy.ALLOW_ALL
+    ports: list[ProtocoRange] = Field(default_factory=list)
 
 
 class ResourceProtocols(BaseModel):
@@ -49,9 +49,9 @@ class ResourceProtocols(BaseModel):
         frozen=True, populate_by_name=True, alias_generator=to_camel
     )
 
-    allow_icmp: bool | None = None
-    tcp: ResourceProtocol | None = None
-    udp: ResourceProtocol | None = None
+    allow_icmp: bool = True
+    tcp: ResourceProtocol = Field(default_factory=ResourceProtocol)
+    udp: ResourceProtocol = Field(default_factory=ResourceProtocol)
 
 
 class Resource(BaseModel):
@@ -69,13 +69,7 @@ class Resource(BaseModel):
     security_policy: ResourceSecurityPolicy | None = Field(
         alias="securityPolicy", default=None
     )
-    protocols: ResourceProtocols = Field(
-        default_factory=lambda: ResourceProtocols(
-            allow_icmp=True,
-            tcp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
-            udp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
-        )
-    )
+    protocols: ResourceProtocols = Field(default_factory=ResourceProtocols)
 
     @staticmethod
     def get_graphql_fragment():

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -122,18 +122,20 @@ class Resource(BaseModel):
         )
 
     def to_spec(self, **overrides: Any) -> ResourceSpec:
-        data = dict(
-            id=self.id,
-            name=self.name,
-            address=self.address.value,
-            alias=self.alias,
-            is_visible=self.is_visible,
-            is_browser_shortcut_enabled=self.is_browser_shortcut_enabled,
-            remote_network_id=self.remote_network.id,
-            security_policy_id=(
-                self.security_policy.id if self.security_policy else None
-            ),
-            protocols=self.protocols.model_dump() if self.protocols else None,
+        data = self.dict(
+            include=[
+                "id",
+                "name",
+                "address",
+                "alias",
+                "is_visible",
+                "is_browser_shortcut_enabled",
+                "protocols",
+            ]
+        )
+        data["remote_network_id"] = self.remote_network.id
+        data["security_policy_id"] = (
+            self.security_policy.id if self.security_policy else None
         )
         data.update(overrides)
         return ResourceSpec(**data)  # type: ignore

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -115,7 +115,7 @@ class Resource(BaseModel):
             and self.alias == crd.alias
             and self.is_visible == crd.is_visible
             and self.is_browser_shortcut_enabled == crd.is_browser_shortcut_enabled
-            and self.protocols == crd.protocols
+            and self.protocols.dict() == crd.protocols.dict()
             and self.remote_network.id == crd.remote_network_id
             and (self.security_policy and self.security_policy.id)
             == crd.security_policy_id
@@ -133,7 +133,7 @@ class Resource(BaseModel):
             security_policy_id=(
                 self.security_policy.id if self.security_policy else None
             ),
-            protocols=self.protocols,
+            protocols=self.protocols.model_dump() if self.protocols else None,
         )
         data.update(overrides)
         return ResourceSpec(**data)  # type: ignore

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -109,13 +109,16 @@ class Resource(BaseModel):
         """
 
     def is_matching_spec(self, crd: ResourceSpec) -> bool:
+        self_protocols = self.protocols.dict() if self.protocols else None
+        crd_protocols = crd.protocols.dict() if crd.protocols else None
+
         return (
             self.name == crd.name
             and self.address.value == crd.address
             and self.alias == crd.alias
             and self.is_visible == crd.is_visible
             and self.is_browser_shortcut_enabled == crd.is_browser_shortcut_enabled
-            and self.protocols.dict() == crd.protocols.dict()
+            and self_protocols == crd_protocols
             and self.remote_network.id == crd.remote_network_id
             and (self.security_policy and self.security_policy.id)
             == crd.security_policy_id

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -126,13 +126,13 @@ class Resource(BaseModel):
             include=[
                 "id",
                 "name",
-                "address",
                 "alias",
                 "is_visible",
                 "is_browser_shortcut_enabled",
                 "protocols",
             ]
         )
+        data["address"] = self.address.value
         data["remote_network_id"] = self.remote_network.id
         data["security_policy_id"] = (
             self.security_policy.id if self.security_policy else None

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -69,7 +69,11 @@ class Resource(BaseModel):
     security_policy: ResourceSecurityPolicy | None = Field(
         alias="securityPolicy", default=None
     )
-    protocols: ResourceProtocols | None = None
+    protocols: ResourceProtocols = ResourceProtocols(
+        allow_icmp=True,
+        tcp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
+        udp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
+    )
 
     @staticmethod
     def get_graphql_fragment():
@@ -240,7 +244,7 @@ class TwingateResourceAPIs:
                 "isBrowserShortcutEnabled": resource.is_browser_shortcut_enabled,
                 "remoteNetworkId": resource.remote_network_id,
                 "securityPolicyId": resource.security_policy_id,
-                "protocols": resource.protocols,
+                "protocols": resource.protocols.dict(by_alias=True),
             },
         )
 
@@ -261,7 +265,7 @@ class TwingateResourceAPIs:
                 "isBrowserShortcutEnabled": resource.is_browser_shortcut_enabled,
                 "remoteNetworkId": resource.remote_network_id,
                 "securityPolicyId": resource.security_policy_id,
-                "protocols": resource.protocols,
+                "protocols": resource.protocols.dict(by_alias=True),
             },
         )
         return Resource(**result["entity"])

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -69,10 +69,12 @@ class Resource(BaseModel):
     security_policy: ResourceSecurityPolicy | None = Field(
         alias="securityPolicy", default=None
     )
-    protocols: ResourceProtocols = ResourceProtocols(
-        allow_icmp=True,
-        tcp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
-        udp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
+    protocols: ResourceProtocols = Field(
+        default_factory=lambda: ResourceProtocols(
+            allow_icmp=True,
+            tcp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
+            udp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
+        )
     )
 
     @staticmethod

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -130,14 +130,14 @@ class Resource(BaseModel):
 
     def to_spec(self, **overrides: Any) -> ResourceSpec:
         data = self.dict(
-            include=[
+            include={
                 "id",
                 "name",
                 "alias",
                 "is_visible",
                 "is_browser_shortcut_enabled",
                 "protocols",
-            ]
+            }
         )
         data["address"] = self.address.value
         data["remote_network_id"] = self.remote_network.id
@@ -145,7 +145,7 @@ class Resource(BaseModel):
             self.security_policy.id if self.security_policy else None
         )
         data.update(overrides)
-        return ResourceSpec(**data)  # type: ignore
+        return ResourceSpec(**data)
 
 
 # fmt:off

--- a/app/api/tests/test_client_resources.py
+++ b/app/api/tests/test_client_resources.py
@@ -5,6 +5,7 @@ from pydantic_core._pydantic_core import ValidationError
 
 from app.api.client import GraphQLMutationError
 from app.api.client_resources import Resource
+from app.crds import ResourceSpec
 
 
 @pytest.fixture()
@@ -66,6 +67,41 @@ class TestResourceModel:
         r1 = Resource(**r.model_dump())
         r1.alias = r.alias + "1"
         assert not r1.is_matching_spec(crd)
+
+    def test_is_matching_case_protocols(self):
+        resource = Resource(
+            **{  # noqa: PIE804
+                "id": "UmVzb3VyY2U6MTI3NTIxMw==",
+                "name": "My K8S Resource",
+                "createdAt": "2024-02-15T01:13:51.059028+00:00",
+                "updatedAt": "2024-02-15T01:20:24.242272+00:00",
+                "address": {"type": "DNS", "value": "my.default.cluster.local"},
+                "alias": "mine.local",
+                "isVisible": True,
+                "isBrowserShortcutEnabled": False,
+                "remoteNetwork": {"id": "UmVtb3RlTmV0d29yazo5Njc0OTU="},
+                "securityPolicy": None,
+                "protocols": {
+                    "allowIcmp": True,
+                    "tcp": {"policy": "ALLOW_ALL", "ports": []},
+                    "udp": {"policy": "ALLOW_ALL", "ports": []},
+                },
+            }
+        )
+
+        crd = ResourceSpec(
+            **{  # noqa: PIE804
+                "address": "my.default.cluster.local",
+                "alias": "mine.local",
+                "id": "UmVzb3VyY2U6MTI3NTIxMw==",
+                "isBrowserShortcutEnabled": False,
+                "isVisible": True,
+                "name": "My K8S Resource",
+                "remoteNetworkId": "UmVtb3RlTmV0d29yazo5Njc0OTU=",
+            }
+        )
+
+        assert resource.is_matching_spec(crd)
 
 
 class TestResourceFactory:

--- a/app/crds.py
+++ b/app/crds.py
@@ -85,7 +85,7 @@ class ResourceProtocol(BaseModel):
     )
 
     policy: ProtocolPolicy
-    ports: list[ProtocoRange] | None = None
+    ports: list[ProtocoRange] = []
 
     @model_validator(mode="after")
     def check_policy_ports(self):
@@ -104,8 +104,8 @@ class ResourceProtocols(BaseModel):
     )
 
     allow_icmp: bool | None = None
-    tcp: ResourceProtocol | None = None
-    udp: ResourceProtocol | None = None
+    tcp: ResourceProtocol = ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL)
+    udp: ResourceProtocol = ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL)
 
 
 class ResourceSpec(BaseModel):

--- a/app/crds.py
+++ b/app/crds.py
@@ -123,7 +123,7 @@ class ResourceSpec(BaseModel):
     security_policy_id: str | None = None
     is_visible: bool = True
     is_browser_shortcut_enabled: bool = True
-    protocols: ResourceProtocols | None = ResourceProtocols(
+    protocols: ResourceProtocols = ResourceProtocols(
         allow_icmp=True,
         tcp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
         udp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),

--- a/app/crds.py
+++ b/app/crds.py
@@ -123,7 +123,7 @@ class ResourceSpec(BaseModel):
     security_policy_id: str | None = None
     is_visible: bool = True
     is_browser_shortcut_enabled: bool = True
-    protocols: ResourceProtocols = ResourceProtocols(
+    protocols: ResourceProtocols | None = ResourceProtocols(
         allow_icmp=True,
         tcp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
         udp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),

--- a/app/crds.py
+++ b/app/crds.py
@@ -123,7 +123,11 @@ class ResourceSpec(BaseModel):
     security_policy_id: str | None = None
     is_visible: bool = True
     is_browser_shortcut_enabled: bool = True
-    protocols: ResourceProtocols | None = None
+    protocols: ResourceProtocols = ResourceProtocols(
+        allow_icmp=True,
+        tcp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
+        udp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
+    )
 
     def __is_wildcard(self):
         return "*" in self.address or "?" in self.address

--- a/app/crds.py
+++ b/app/crds.py
@@ -84,7 +84,7 @@ class ResourceProtocol(BaseModel):
         frozen=True, populate_by_name=True, alias_generator=to_camel
     )
 
-    policy: ProtocolPolicy
+    policy: ProtocolPolicy = ProtocolPolicy.ALLOW_ALL
     ports: list[ProtocoRange] = Field(default_factory=list)
 
     @model_validator(mode="after")
@@ -104,12 +104,8 @@ class ResourceProtocols(BaseModel):
     )
 
     allow_icmp: bool | None = True
-    tcp: ResourceProtocol = Field(
-        default_factory=lambda: ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL)
-    )
-    udp: ResourceProtocol = Field(
-        default_factory=lambda: ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL)
-    )
+    tcp: ResourceProtocol = Field(default_factory=ResourceProtocol)
+    udp: ResourceProtocol = Field(default_factory=ResourceProtocol)
 
 
 class ResourceSpec(BaseModel):

--- a/app/crds.py
+++ b/app/crds.py
@@ -85,7 +85,7 @@ class ResourceProtocol(BaseModel):
     )
 
     policy: ProtocolPolicy
-    ports: list[ProtocoRange] = []
+    ports: list[ProtocoRange] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def check_policy_ports(self):
@@ -103,9 +103,13 @@ class ResourceProtocols(BaseModel):
         frozen=True, populate_by_name=True, alias_generator=to_camel
     )
 
-    allow_icmp: bool | None = None
-    tcp: ResourceProtocol = ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL)
-    udp: ResourceProtocol = ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL)
+    allow_icmp: bool | None = True
+    tcp: ResourceProtocol = Field(
+        default_factory=lambda: ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL)
+    )
+    udp: ResourceProtocol = Field(
+        default_factory=lambda: ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL)
+    )
 
 
 class ResourceSpec(BaseModel):
@@ -123,11 +127,7 @@ class ResourceSpec(BaseModel):
     security_policy_id: str | None = None
     is_visible: bool = True
     is_browser_shortcut_enabled: bool = True
-    protocols: ResourceProtocols = ResourceProtocols(
-        allow_icmp=True,
-        tcp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
-        udp=ResourceProtocol(policy=ProtocolPolicy.ALLOW_ALL, ports=[]),
-    )
+    protocols: ResourceProtocols = Field(default_factory=ResourceProtocols)
 
     def __is_wildcard(self):
         return "*" in self.address or "?" in self.address

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ markers = [
     "integration",
 ]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
     "D",
     "F", # Pyflakes
@@ -145,7 +145,7 @@ ignore = [
     "D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107",
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "*/tests/*" = [
     "S101", # Use of `assert` detected
     "S106", # Possible hardcoded password assigned to argument

--- a/tests_integration/test_resource_flows.py
+++ b/tests_integration/test_resource_flows.py
@@ -23,6 +23,17 @@ def test_resource_flows(kopf_settings, kopf_runner_args, unique_resource_name):
         spec:
           name: My K8S Resource
           address: my.default.cluster.local
+          protocols:
+            allowIcmp: false
+            tcp:
+                policy: RESTRICTED
+                ports:
+                    - start: 80
+                      end: 80
+            udp:
+                policy: ALLOW_ALL
+                ports: []
+
     """
 
     OBJ_UPDATED = f"""
@@ -33,13 +44,21 @@ def test_resource_flows(kopf_settings, kopf_runner_args, unique_resource_name):
             spec:
               name: My K8S Resource Renamed
               address: my.default.cluster.local
+              protocols:
+                allowIcmp: false
+                tcp:
+                    policy: ALLOW_ALL
+                    ports: []
+                udp:
+                    policy: ALLOW_ALL
+                    ports: []
+
         """
 
     # fmt: off
     with KopfRunner(kopf_runner_args, settings=kopf_settings) as runner:
         kubectl_create(OBJ)
         time.sleep(5)  # give it some time to react
-
         created_object = json.loads(kubectl(f"get tgr/{unique_resource_name} -o json").stdout)
 
         # Update the name

--- a/tests_integration/test_resource_flows.py
+++ b/tests_integration/test_resource_flows.py
@@ -30,10 +30,6 @@ def test_resource_flows(kopf_settings, kopf_runner_args, unique_resource_name):
                 ports:
                     - start: 80
                       end: 80
-            udp:
-                policy: ALLOW_ALL
-                ports: []
-
     """
 
     OBJ_UPDATED = f"""
@@ -46,12 +42,11 @@ def test_resource_flows(kopf_settings, kopf_runner_args, unique_resource_name):
               address: my.default.cluster.local
               protocols:
                 allowIcmp: false
-                tcp:
-                    policy: ALLOW_ALL
-                    ports: []
                 udp:
-                    policy: ALLOW_ALL
-                    ports: []
+                    policy: RESTRICTED
+                    ports:
+                        - start: 80
+                          end: 80
 
         """
 


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #145 

## Changes

Fixed `Resource.is_matching_spec` - it was not comparing `protocols` properly so would always return false causing `twingate_resource_sync` to always think there's a drift and issue an update call



