### PR TITLE
fix: Deleting an item already deleted on Twingate Admin should not fail

### DIFF
--- a/app/api/client.py
+++ b/app/api/client.py
@@ -12,6 +12,7 @@ from app.api.client_connectors import TwingateConnectorAPI
 from app.api.client_remote_networks import TwingateRemoteNetworksAPIs
 from app.api.client_resources import TwingateResourceAPIs
 from app.api.client_resources_access import TwingateResourceAccessAPIs
+from app.api.exceptions import GraphQLMutationError
 from app.settings import TwingateOperatorSettings, get_version
 
 log = logging.getLogger(__name__)
@@ -62,14 +63,6 @@ class TwingateRequestsHTTPTransport(RequestsHTTPTransport):
             )
             for prefix in "http://", "https://":
                 self.session.mount(prefix, adapter)
-
-
-class GraphQLMutationError(Exception):
-    def __init__(self, mutation_name: str, error: str):
-        self.mutation_name = mutation_name
-        self.error = error
-        self.message = f"{mutation_name} mutation failed."
-        super().__init__(self.message)
 
 
 class TwingateAPIClient(

--- a/app/api/client_connectors.py
+++ b/app/api/client_connectors.py
@@ -5,6 +5,7 @@ from gql.transport.exceptions import TransportQueryError
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
+from app.api.exceptions import GraphQLMutationError
 from app.api.protocol import TwingateClientProtocol
 from app.crds import ConnectorSpec
 
@@ -139,5 +140,10 @@ class TwingateConnectorAPI:
             )
 
             return bool(result["ok"])
+        except GraphQLMutationError as gql_err:
+            if "does not exist" in gql_err.error:
+                return True
+
+            raise
         except TransportQueryError:
             return False

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -7,6 +7,7 @@ from gql.transport.exceptions import TransportQueryError
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
+from app.api.exceptions import GraphQLMutationError
 from app.api.protocol import TwingateClientProtocol
 from app.crds import ProtocolPolicy, ResourceSpec
 
@@ -275,5 +276,10 @@ class TwingateResourceAPIs:
             )
 
             return bool(result["ok"])
+        except GraphQLMutationError as gql_err:
+            if "down not exist" in gql_err.error:
+                return True
+
+            raise
         except TransportQueryError:
             return False

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -277,7 +277,7 @@ class TwingateResourceAPIs:
 
             return bool(result["ok"])
         except GraphQLMutationError as gql_err:
-            if "down not exist" in gql_err.error:
+            if "does not exist" in gql_err.error:
                 return True
 
             raise

--- a/app/api/exceptions.py
+++ b/app/api/exceptions.py
@@ -1,0 +1,6 @@
+class GraphQLMutationError(Exception):
+    def __init__(self, mutation_name: str, error: str):
+        self.mutation_name = mutation_name
+        self.error = error
+        self.message = f"{mutation_name} mutation failed."
+        super().__init__(self.message)

--- a/app/api/tests/test_client_resources.py
+++ b/app/api/tests/test_client_resources.py
@@ -285,3 +285,30 @@ class TestTwingateResourceAPIs:
         )
         result = api_client.resource_delete("some-id")
         assert result is False
+
+    def test_resource_delete_with_id_already_deleted_returns_true(
+        self, test_url, api_client, mocked_responses
+    ):
+        failed_response = json.dumps(
+            {
+                "data": {
+                    "resourceDelete": {
+                        "ok": False,
+                        "error": "Resource with id 'some-id' does not exist",
+                    }
+                }
+            }
+        )
+
+        mocked_responses.post(
+            test_url,
+            status=200,
+            body=failed_response,
+            match=[
+                responses.matchers.json_params_matcher(
+                    {"variables": {"id": "some-id"}}, strict_match=False
+                )
+            ],
+        )
+        result = api_client.resource_delete("some-id")
+        assert result is True

--- a/app/api/tests/test_connectors.py
+++ b/app/api/tests/test_connectors.py
@@ -196,3 +196,30 @@ class TestTwingateConnectorAPI:
         )
         result = api_client.connector_delete("some-id")
         assert result is False
+
+    def test_connector_delete_with_id_already_deleted_returns_true(
+        self, test_url, api_client, mocked_responses
+    ):
+        failed_response = json.dumps(
+            {
+                "data": {
+                    "connectorDelete": {
+                        "ok": False,
+                        "error": "Connector with id 'some-id' does not exist",
+                    }
+                }
+            }
+        )
+
+        mocked_responses.post(
+            test_url,
+            status=200,
+            body=failed_response,
+            match=[
+                responses.matchers.json_params_matcher(
+                    {"variables": {"id": "some-id"}}, strict_match=False
+                )
+            ],
+        )
+        result = api_client.connector_delete("some-id")
+        assert result is True


### PR DESCRIPTION
## Related Tickets & Documents

Fix #159 

## Changes

- Treat delete mustation of an entity no longer in Twingate as a success
