### PR TITLE
fix: twingate connector doesnt handle pod deletion on resume

### DIFF
--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -146,7 +146,7 @@ def test_connector_flowes_image_change(kopf_settings, kopf_runner_args, ci_run_n
 
 
 def test_pod_gone_while_operator_down(kopf_settings, kopf_runner_args, ci_run_number):
-    connector_name = f"test-connector-image-{ci_run_number}"
+    connector_name = f"test-connector-gone-{ci_run_number}"
     OBJ = f"""
         apiVersion: twingate.com/v1beta
         kind: TwingateConnector


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #161 

## Changes

On TwingateConnector resume event check if pod exists
