### PR TITLE
fix: Add status and logs to `twingate_connector_resume`

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -143,7 +143,7 @@ def twingate_connector_resume(body, patch, namespace, logger, **_):
     pod_exists = True
     if not check_pod_exists(namespace, crd.metadata.name):
         logger.info(
-            "Pod is gone. Adding LABEL_CONNECTOR_POD_DELETED label to trigger recreation"
+            "Pod is gone. Adding LABEL_CONNECTOR_POD_DELETED label to trigger recreation."
         )
         patch.meta["labels"] = {LABEL_CONNECTOR_POD_DELETED: "true"}
         pod_exists = False

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -140,16 +140,18 @@ def twingate_connector_resume(body, patch, namespace, logger, **_):
     patch.meta["annotations"] = {ANNOTATION_NEXT_VERSION_CHECK: next_version_check}
 
     # Check pod exists and if not, add LABEL_CONNECTOR_POD_DELETED label to trigger recreation
-    pod_requires_recreation = False
+    pod_exists = True
     if not check_pod_exists(namespace, crd.metadata.name):
         logger.info(
             "Pod is gone. Adding LABEL_CONNECTOR_POD_DELETED label to trigger recreation"
         )
         patch.meta["labels"] = {LABEL_CONNECTOR_POD_DELETED: "true"}
-        pod_requires_recreation = True
+        pod_exists = False
 
     return success(
-        twingate_id=crd.spec.id, pod_requires_recreation=pod_requires_recreation
+        twingate_id=crd.spec.id,
+        pod_exists=pod_exists,
+        next_version_check=next_version_check,
     )
 
 

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -140,13 +140,12 @@ def twingate_connector_resume(body, patch, namespace, logger, **_):
     patch.meta["annotations"] = {ANNOTATION_NEXT_VERSION_CHECK: next_version_check}
 
     # Check pod exists and if not, add LABEL_CONNECTOR_POD_DELETED label to trigger recreation
-    pod_exists = True
-    if not check_pod_exists(namespace, crd.metadata.name):
+    pod_exists = check_pod_exists(namespace, crd.metadata.name)
+    if not pod_exists:
         logger.info(
             "Pod is gone. Adding LABEL_CONNECTOR_POD_DELETED label to trigger recreation."
         )
         patch.meta["labels"] = {LABEL_CONNECTOR_POD_DELETED: "true"}
-        pod_exists = False
 
     return success(
         twingate_id=crd.spec.id,


### PR DESCRIPTION
## Changes

- Added return status to `twingate_connector_resume` 
- Added log when pod requires recreation