### PR TITLE
fix: Limit twingate_resource_access_update scope to spec

### DIFF
--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -47,10 +47,10 @@ def twingate_resource_access_create(body, spec, memo, logger, patch, **kwargs):
 
 
 @kopf.on.update("twingateresourceaccess", field="spec")
-def twingate_resource_access_update(spec, new, diff, status, memo, logger, **kwargs):
+def twingate_resource_access_update(spec, diff, status, memo, logger, **kwargs):
     logger.info(
         "Got TwingateResourceAccess update request: %s. Diff: %s. Status: %s.",
-        new,
+        spec,
         diff,
         status,
     )

--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -46,8 +46,8 @@ def twingate_resource_access_create(body, spec, memo, logger, patch, **kwargs):
         return fail(error=mex.error)
 
 
-@kopf.on.update("twingateresourceaccess")
-def twingate_resource_access_update(new, diff, status, memo, logger, **kwargs):
+@kopf.on.update("twingateresourceaccess", field="spec")
+def twingate_resource_access_update(spec, new, diff, status, memo, logger, **kwargs):
     logger.info(
         "Got TwingateResourceAccess update request: %s. Diff: %s. Status: %s.",
         new,
@@ -61,7 +61,7 @@ def twingate_resource_access_update(new, diff, status, memo, logger, **kwargs):
 
     # Note that both principalId and resourceRef are immutable so only securityPolicyId could change
     # in this case we just need to call api_client.resource_access_add with the new value
-    access_crd = ResourceAccessSpec(**new["spec"])
+    access_crd = ResourceAccessSpec(**spec)
     if resource_crd := access_crd.get_resource():
         try:
             client = TwingateAPIClient(memo.twingate_settings)

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -201,7 +201,8 @@ class TestResourceAccessUpdateHandler:
             return_value=resource_crd_mock,
         ):
             result = twingate_resource_access_update(
-                new={"spec": resource_access_spec},
+                spec=resource_access_spec,
+                new=resource_access_spec,
                 diff={},
                 status=status,
                 memo=memo_mock,
@@ -226,7 +227,8 @@ class TestResourceAccessUpdateHandler:
             return_value=None,
         ):
             result = twingate_resource_access_update(
-                new={"spec": resource_access_spec},
+                spec=resource_access_spec,
+                new=resource_access_spec,
                 diff={},
                 status=status,
                 memo=memo_mock,
@@ -239,7 +241,7 @@ class TestResourceAccessUpdateHandler:
             }
 
     def test_update_resource_not_yet_created_should_raise_temp_error(self):
-        new = {"spec": {"principalId": "R3JvdXA6MTE1NzI2MA=="}}
+        new = {"principalId": "R3JvdXA6MTE1NzI2MA=="}
         diff = {}
         status = {}
         logger_mock = MagicMock()
@@ -247,7 +249,12 @@ class TestResourceAccessUpdateHandler:
 
         with pytest.raises(kopf.TemporaryError) as excinfo:
             twingate_resource_access_update(
-                new=new, diff=diff, status=status, memo=memo_mock, logger=logger_mock
+                spec=new,
+                new=new,
+                diff=diff,
+                status=status,
+                memo=memo_mock,
+                logger=logger_mock,
             )
 
         assert excinfo.value.args[0] == "Resource not yet created, retrying..."

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -202,7 +202,6 @@ class TestResourceAccessUpdateHandler:
         ):
             result = twingate_resource_access_update(
                 spec=resource_access_spec,
-                new=resource_access_spec,
                 diff={},
                 status=status,
                 memo=memo_mock,
@@ -228,7 +227,6 @@ class TestResourceAccessUpdateHandler:
         ):
             result = twingate_resource_access_update(
                 spec=resource_access_spec,
-                new=resource_access_spec,
                 diff={},
                 status=status,
                 memo=memo_mock,
@@ -250,7 +248,6 @@ class TestResourceAccessUpdateHandler:
         with pytest.raises(kopf.TemporaryError) as excinfo:
             twingate_resource_access_update(
                 spec=new,
-                new=new,
                 diff=diff,
                 status=status,
                 memo=memo_mock,


### PR DESCRIPTION
## Related Tickets & Documents

Fixes #174 

## Changes

Limit the update scope of `twingate_resource_access_update` to just the `spec` field
