### PR TITLE
fix: Reduce update scope for `twingate_resource_update`

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -168,7 +168,7 @@ def twingate_connector_update(body, memo, logger, new, diff, status, **_):
 
     crd = TwingateConnectorCRD(**body)
     if not crd.spec.id:
-        return fail(reason="Update called before Connector has an ID")
+        return fail(error="Update called before Connector has an ID")
 
     updated_connector = client.connector_update(crd.spec)
     return success(twingate_id=updated_connector.id)

--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -22,17 +22,18 @@ def twingate_resource_create(body, spec, memo, logger, patch, **kwargs):
 
 
 @kopf.on.update("twingateresource", field="spec")
-def twingate_resource_update(spec, new, diff, status, memo, logger, **kwargs):
+def twingate_resource_update(spec, diff, status, memo, logger, **kwargs):
     logger.info(
         "Got TwingateResource update request: %s. Diff: %s. Status: %s.",
-        new,
+        spec,
         diff,
         status,
     )
 
     crd = ResourceSpec(**spec)
 
-    if len(diff) == 1 and diff[0][0] == "add" and diff[0][1] == ("id",):
+    # Check if just "id" was added - means `create` just ran
+    if len(diff) == 1 and next(iter(diff), [])[:3] == ("add", ("id",), None):
         return success(twingate_id=crd.id, message="No update required")
 
     if crd.id:

--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -31,6 +31,10 @@ def twingate_resource_update(spec, new, diff, status, memo, logger, **kwargs):
     )
 
     crd = ResourceSpec(**spec)
+
+    if len(diff) == 1 and diff[0][0] == "add" and diff[0][1] == ("id",):
+        return success(twingate_id=crd.id, message="No update required")
+
     if crd.id:
         logger.info("Updating resource %s", crd.id)
         client = TwingateAPIClient(memo.twingate_settings)

--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -21,8 +21,8 @@ def twingate_resource_create(body, spec, memo, logger, patch, **kwargs):
     )
 
 
-@kopf.on.update("twingateresource")
-def twingate_resource_update(old, new, diff, status, memo, logger, **kwargs):
+@kopf.on.update("twingateresource", field="spec")
+def twingate_resource_update(spec, new, diff, status, memo, logger, **kwargs):
     logger.info(
         "Got TwingateResource update request: %s. Diff: %s. Status: %s.",
         new,
@@ -30,7 +30,7 @@ def twingate_resource_update(old, new, diff, status, memo, logger, **kwargs):
         status,
     )
 
-    crd = ResourceSpec(**new["spec"])
+    crd = ResourceSpec(**spec)
     if crd.id:
         logger.info("Updating resource %s", crd.id)
         client = TwingateAPIClient(memo.twingate_settings)

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -222,7 +222,7 @@ def test_twingate_connector_update_without_id_does_nothing(
         twingate_connector_update, crd, MagicMock(), new={}, diff={}
     )
     assert run.result == {
-        "reason": "Update called before Connector has an ID",
+        "error": "Update called before Connector has an ID",
         "success": False,
         "ts": ANY,
     }

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -89,6 +89,29 @@ class TestResourceUpdateHandler:
         mock_api_client.resource_update.assert_called_once_with(new_resource_spec)
         assert patch_mock.spec == {}
 
+    def test_update_called_without_id_fails(self, mock_api_client):
+        spec = {
+            "address": "my.default.cluster.local",
+            "name": "new-name",
+        }
+        diff = []
+        status = {}
+
+        logger_mock = MagicMock()
+        memo_mock = MagicMock()
+        patch_mock = MagicMock()
+        patch_mock.spec = {}
+
+        result = twingate_resource_update(spec, diff, status, memo_mock, logger_mock)
+        assert result == {
+            "success": False,
+            "error": "Resource ID is missing in the spec",
+            "ts": ANY,
+        }
+
+        mock_api_client.resource_update.assert_not_called()
+        assert patch_mock.spec == {}
+
     def test_update_caused_by_create_does_nothing(self, mock_api_client):
         rid = "UmVzb3VyY2U6OTMxODE3"
         spec = {

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -91,6 +91,42 @@ class TestResourceUpdateHandler:
         mock_api_client.resource_update.assert_called_once_with(new_resource_spec)
         assert patch_mock.spec == {}
 
+    def test_update_caused_by_create_does_nothing(self, mock_api_client):
+        rid = "UmVzb3VyY2U6OTMxODE3"
+        spec = new = {
+            "id": rid,
+            "address": "my.default.cluster.local",
+            "name": "new-name",
+        }
+        diff = (("add", ("id",), rid),)
+        status = {
+            "twingate_resource_create": {
+                "twingate_id": rid,
+                "created_at": "2023-09-27T04:02:55.249011+00:00",
+                "updated_at": "2023-09-27T04:02:55.249035+00:00",
+            }
+        }
+
+        mock_api_client.resource_update.return_value = MagicMock(id=rid)
+
+        logger_mock = MagicMock()
+        memo_mock = MagicMock()
+        patch_mock = MagicMock()
+        patch_mock.spec = {}
+
+        result = twingate_resource_update(
+            spec, new, diff, status, memo_mock, logger_mock
+        )
+        assert result == {
+            "success": True,
+            "twingate_id": rid,
+            "message": "No update required",
+            "ts": ANY,
+        }
+
+        mock_api_client.resource_update.assert_not_called()
+        assert patch_mock.spec == {}
+
 
 class TestResourceDeleteHandler:
     def test_delete(self, mock_api_client):

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -55,21 +55,12 @@ class TestResourceCreateHandler:
 class TestResourceUpdateHandler:
     def test_update(self, mock_api_client):
         rid = "UmVzb3VyY2U6OTMxODE3"
-        old = {
-            "spec": {
-                "id": rid,
-                "address": "my.default.cluster.local",
-                "name": "My K8S Resource",
-            }
+        spec = new = {
+            "id": rid,
+            "address": "my.default.cluster.local",
+            "name": "new-name",
         }
-        new = {
-            "spec": {
-                "id": rid,
-                "address": "my.default.cluster.local",
-                "name": "new-name",
-            }
-        }
-        diff = (("change", ("spec", "name"), "My K8S Resource", "new-name"),)
+        diff = (("change", ("name"), "My K8S Resource", "new-name"),)
         status = {
             "twingate_resource_create": {
                 "twingate_id": rid,
@@ -77,7 +68,7 @@ class TestResourceUpdateHandler:
                 "updated_at": "2023-09-27T04:02:55.249035+00:00",
             }
         }
-        new_resource_spec = ResourceSpec(**new["spec"])
+        new_resource_spec = ResourceSpec(**new)
 
         mock_api_client.resource_update.return_value = MagicMock(id=rid)
 
@@ -87,7 +78,7 @@ class TestResourceUpdateHandler:
         patch_mock.spec = {}
 
         result = twingate_resource_update(
-            old, new, diff, status, memo_mock, logger_mock
+            spec, new, diff, status, memo_mock, logger_mock
         )
         assert result == {
             "success": True,

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -77,9 +77,7 @@ class TestResourceUpdateHandler:
         patch_mock = MagicMock()
         patch_mock.spec = {}
 
-        result = twingate_resource_update(
-            spec, new, diff, status, memo_mock, logger_mock
-        )
+        result = twingate_resource_update(spec, diff, status, memo_mock, logger_mock)
         assert result == {
             "success": True,
             "twingate_id": rid,
@@ -93,12 +91,12 @@ class TestResourceUpdateHandler:
 
     def test_update_caused_by_create_does_nothing(self, mock_api_client):
         rid = "UmVzb3VyY2U6OTMxODE3"
-        spec = new = {
+        spec = {
             "id": rid,
             "address": "my.default.cluster.local",
             "name": "new-name",
         }
-        diff = (("add", ("id",), rid),)
+        diff = (("add", ("id",), None, rid),)
         status = {
             "twingate_resource_create": {
                 "twingate_id": rid,
@@ -114,9 +112,7 @@ class TestResourceUpdateHandler:
         patch_mock = MagicMock()
         patch_mock.spec = {}
 
-        result = twingate_resource_update(
-            spec, new, diff, status, memo_mock, logger_mock
-        )
+        result = twingate_resource_update(spec, diff, status, memo_mock, logger_mock)
         assert result == {
             "success": True,
             "twingate_id": rid,


### PR DESCRIPTION
## Related Tickets & Documents

Fixes #173 

## Changes

`twingate_resource_update` should only care when `spec` updates
