### PR TITLE
fix: LABEL_CONNECTOR_POD_DELETED isnt set to false after pod recreated

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -263,9 +263,7 @@ def twingate_connector_recreate_pod(body, namespace, memo, patch, logger, **_):
 
     pod = get_connector_pod(crd, settings.full_url, image)
     kopf.adopt(pod, owner=body, strict=True, forced=True)
-    kopf.label(
-        pod, {LABEL_CONNECTOR: crd.metadata.name, LABEL_CONNECTOR_POD_DELETED: "false"}
-    )
+    kopf.label(pod, {"twingate.com/connector": crd.metadata.name})
 
     retry_count = 0
     kapi = kubernetes.client.CoreV1Api()

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -237,7 +237,7 @@ def timer_check_image_version(body, meta, namespace, memo, logger, patch, **_):
 
 
 @kopf.on.update("twingateconnector", labels={LABEL_CONNECTOR_POD_DELETED: "true"})
-def twingate_connector_recreate_pod(body, namespace, memo, logger, **_):
+def twingate_connector_recreate_pod(body, namespace, memo, patch, logger, **_):
     """Recreates the Connector's Pod.
 
     When pod is deleted we can't recreate it right away because we want to
@@ -287,6 +287,8 @@ def twingate_connector_recreate_pod(body, namespace, memo, logger, **_):
                 time.sleep(2)
             else:
                 raise
+
+    patch.metadata["labels"] = {LABEL_CONNECTOR_POD_DELETED: None}
 
 
 @kopf.on.delete("twingateconnector")

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -286,7 +286,7 @@ def twingate_connector_recreate_pod(body, namespace, memo, patch, logger, **_):
             else:
                 raise
 
-    patch.metadata["labels"] = {LABEL_CONNECTOR_POD_DELETED: None}
+    patch.meta["labels"] = {LABEL_CONNECTOR_POD_DELETED: None}
 
 
 @kopf.on.delete("twingateconnector")

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -330,6 +330,7 @@ def test_twingate_connector_recreate_pod(get_connector_and_crd, kopf_handler_run
         ANY, {"twingate.com/connector": crd.spec.name}
     )
     run.k8s_client_mock.create_namespaced_pod.assert_called_once()
+    assert run.patch_mock.meta["labels"][LABEL_CONNECTOR_POD_DELETED] is None
 
 
 def test_twingate_connector_delete_deletes_connector(

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -71,6 +71,10 @@ def test_connector_flows(kopf_settings, kopf_runner_args, ci_run_number):
         assert pod["metadata"]["ownerReferences"][0]["name"] == connector_name
         assert pod["metadata"]["ownerReferences"][0]["kind"] == "TwingateConnector"
 
+        # Check that LABEL_CONNECTOR_POD_DELETED label is gone
+        connector = kubectl_get("tc", connector_name)
+        assert not connector["metadata"].get("labels", {}).get("twingate.com/connector-pod-deleted")  # fmt: skip
+
         kubectl_delete(f"tc/{connector_name}")
         time.sleep(5)
 


### PR DESCRIPTION
## Changes

`twingate_connector_recreate_pod` should remove the `LABEL_CONNECTOR_POD_DELETED` pod after its done
