### PR TITLE
chore: Integration test for old pod migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test-cov:
 
 .PHONY: test-int
 test-int:
-	poetry run pytest  -m "integration" -s
+	poetry run pytest  -m "integration" -s -v
 
 .PHONY: report-to-coveralls
 report-to-coveralls:

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -153,7 +153,8 @@ def twingate_connector_update(body, memo, logger, new, diff, status, namespace, 
     client = TwingateAPIClient(settings)
 
     crd = TwingateConnectorCRD(**body)
-    if len(diff) == 1 and diff[0][:3] == ("add", ("id"), None):
+    # (('add', ('id',), None, 'Q29ubmVjdG9yOjUwNjE3NQ=='),)
+    if len(diff) == 1 and diff[0][:3] == ("add", ("id",), None):
         return success(twingate_id=crd.spec.id, message="No update required")
 
     if not crd.spec.id:

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -170,7 +170,7 @@ def test_twingate_connector_update_only_id_does_nothing(
         crd,
         MagicMock(),
         new={},
-        diff=(("add", ("id"), None, "123"),),
+        diff=(("add", ("id",), None, "123"),),
     )
     assert run.result == {
         "success": True,

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -1,7 +1,6 @@
-import os
 import time
 from subprocess import CalledProcessError
-from unittest.mock import ANY, patch
+from unittest.mock import ANY
 
 import pytest
 from kopf.testing import KopfRunner
@@ -13,18 +12,6 @@ from tests_integration.utils import (
     kubectl_get,
     kubectl_patch,
 )
-
-
-@pytest.fixture(autouse=True)
-def _connector_reconciler():
-    with patch.dict(
-        os.environ,
-        {
-            "CONNECTOR_RECONCILER_INTERVAL": "1",
-            "CONNECTOR_RECONCILER_INIT_DELAY": "1",
-        },
-    ):
-        yield
 
 
 def test_connector_flows(kopf_settings, kopf_runner_args, ci_run_number):

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -28,7 +28,7 @@ def _connector_reconciler():
 
 
 def test_connector_flows(kopf_settings, kopf_runner_args, ci_run_number):
-    connector_name = f"test-connector-{ci_run_number}"
+    connector_name = f"test-{ci_run_number}"
     OBJ = f"""
         apiVersion: twingate.com/v1beta
         kind: TwingateConnector
@@ -97,7 +97,7 @@ def test_connector_flows(kopf_settings, kopf_runner_args, ci_run_number):
 
 
 def test_connector_flows_image_change(kopf_settings, kopf_runner_args, ci_run_number):
-    connector_name = f"test-connector-image-{ci_run_number}"
+    connector_name = f"test-image-{ci_run_number}"
     OBJ = f"""
         apiVersion: twingate.com/v1beta
         kind: TwingateConnector
@@ -159,7 +159,7 @@ def test_connector_flows_image_change(kopf_settings, kopf_runner_args, ci_run_nu
 def test_connector_flows_pod_gone_while_operator_down(
     kopf_settings, kopf_runner_args, ci_run_number
 ):
-    connector_name = f"test-connector-gone-{ci_run_number}"
+    connector_name = f"test-gone-{ci_run_number}"
     OBJ = f"""
         apiVersion: twingate.com/v1beta
         kind: TwingateConnector
@@ -207,7 +207,7 @@ def test_connector_flows_pod_gone_while_operator_down(
 def test_connector_flows_pod_migration_from_older_pod_with_finalizers(
     kopf_settings, kopf_runner_args, ci_run_number
 ):
-    connector_name = f"test-connector-migration-{ci_run_number}"
+    connector_name = f"test-migration-{ci_run_number}"
     OBJ = f"""
         apiVersion: twingate.com/v1beta
         kind: TwingateConnector

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -255,6 +255,10 @@ def test_connector_flows_pod_migration_from_older_pod_with_finalizers(
 
         # check pod was recreated
         pod = kubectl_get("pod", connector_name)
+        if pod["status"]["phase"] == "Pending":
+            time.sleep(5)
+            pod = kubectl_get("pod", connector_name)
+
         assert pod["metadata"]["annotations"]["twingate.com/connector-podspec-version"] == "v1"  # fmt: skip
         # assert pod["status"]["phase"] in ["Running", "Pending"]
         assert pod["status"]["phase"] == "Running"

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -137,7 +137,7 @@ def test_connector_flows_image_change(kopf_settings, kopf_runner_args, ci_run_nu
         # Change image tag
         # kubectl patch tc/test-connector-image-local -p '{"spec": {"image": {"tag": "1.63.0"}}}' --type=merge
         kubectl_patch(f"tc/{connector_name}", {"spec": {"image": {"tag": "1.63.0"}}})
-        time.sleep(5)
+        time.sleep(10)
         pod = kubectl_get("pod", connector_name)
         assert pod["status"]["phase"] == "Running"
         assert pod["spec"]["containers"][0]["image"] == "twingate/connector:1.63.0"

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -143,7 +143,7 @@ def test_connector_flows_image_change(kopf_settings, kopf_runner_args, ci_run_nu
         assert pod["spec"]["containers"][0]["image"] == "twingate/connector:1.63.0"
 
         kubectl_delete(f"tc/{connector_name}")
-        time.sleep(5)
+        time.sleep(10)
 
         # secret & pod are deleted
         with pytest.raises(CalledProcessError):

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -251,7 +251,7 @@ def test_connector_flows_pod_migration_from_older_pod_with_finalizers(
         )
 
         # wait for timer to run
-        time.sleep(5)
+        time.sleep(10)
 
         # check pod was recreated
         pod = kubectl_get("pod", connector_name)

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -207,7 +207,7 @@ def test_connector_flows_pod_gone_while_operator_down(
 def test_connector_flows_pod_migration_from_older_pod_with_finalizers(
     kopf_settings, kopf_runner_args, ci_run_number
 ):
-    connector_name = f"test-connector-gone-{ci_run_number}"
+    connector_name = f"test-connector-migration-{ci_run_number}"
     OBJ = f"""
         apiVersion: twingate.com/v1beta
         kind: TwingateConnector


### PR DESCRIPTION


## Changes

Tests the fix of #189 by adding `test_connector_flows_pod_migration_from_older_pod_with_finalizers`.
We create a connector, patch the pod with a finalizer and wrong version annotation and make sure the reconciler is able to delete and recreate it.
