### PR TITLE
chore: Upgrade Go to 1.22.0 and setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "13:00"
+    commit-message:
+      prefix: "chore: "
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
     commit-message:
       prefix: "chore: "
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Go 1.21.x
+      - name: Setup Go 1.22.x
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Run Helm Chart Golden Tests
         run: go test -v ./...
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module twingate-helm-charts
 
-go 1.21
+go 1.22
 
 require (
 	github.com/gruntwork-io/terratest v0.46.8


### PR DESCRIPTION

## Changes

- Setup dependabot to update Go dependenciesa
- Upgraded Go to 1.22.0

