### PR TITLE
fix: Allow env to be defined in containerExtra

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -36,6 +36,9 @@ def get_connector_pod(
             },
         ]
 
+    container_extra = spec.container_extra
+    extra_env = container_extra.pop("env", [])
+
     # fmt: off
     pod_spec = {
         "containers": [
@@ -45,7 +48,7 @@ def get_connector_pod(
                     {"name": "TWINGATE_LABEL_OPERATOR_VERSION", "value": get_version()},
                     {"name": "TWINGATE_URL", "value": tenant_url},
                     {"name": "TWINGATE_LOG_LEVEL", "value": str(spec.log_level)},
-                ]+env_labels_version_policy,
+                ] + env_labels_version_policy + extra_env,
                 "envFrom": [
                     {
                         "secretRef": {
@@ -65,7 +68,7 @@ def get_connector_pod(
                     "runAsNonRoot": True,
                     "runAsUser": 65532,
                },
-                **spec.container_extra,
+                **container_extra,
             }
         ],
         **spec.pod_extra,

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -38,6 +38,7 @@ def get_connector_pod(
 
     container_extra = spec.container_extra
     extra_env = container_extra.pop("env", [])
+    extra_env_from = container_extra.pop("envFrom", [])
 
     # fmt: off
     pod_spec = {
@@ -56,7 +57,7 @@ def get_connector_pod(
                             "optional": False
                         }
                     }
-                ],
+                ] + extra_env_from,
                 "image": image,
                 "imagePullPolicy": "Always",
                 "name": "connector",

--- a/app/tests/test_crds_connector.py
+++ b/app/tests/test_crds_connector.py
@@ -20,10 +20,11 @@ def sample_connector_object_image():
             "name": "My K8S Connector",
             "image": {"repository": "twingate/connector", "tag": "1.60.0"},
             "containerExtra": {
+                "env": [{"name": "MY_ENV_VAR", "value": "my_value"}],
                 "resources": {
                     "requests": {"cpu": "100m", "memory": "128Mi"},
                     "limits": {"cpu": "100m", "memory": "128Mi"},
-                }
+                },
             },
         },
     }
@@ -47,10 +48,11 @@ def sample_connector_object_imagepolicy():
                 "version": "0.1.x",
             },
             "containerExtra": {
+                "env": [{"name": "MY_ENV_VAR", "value": "my_value"}],
                 "resources": {
                     "requests": {"cpu": "100m", "memory": "128Mi"},
                     "limits": {"cpu": "100m", "memory": "128Mi"},
-                }
+                },
             },
         },
     }

--- a/app/tests/test_crds_connector.py
+++ b/app/tests/test_crds_connector.py
@@ -65,10 +65,11 @@ def test_deserialization_image(sample_connector_object_image):
     assert crd.spec.image.repository == "twingate/connector"
     assert crd.spec.image.tag == "1.60.0"
     assert crd.spec.container_extra == {
+        "env": [{"name": "MY_ENV_VAR", "value": "my_value"}],
         "resources": {
             "limits": {"cpu": "100m", "memory": "128Mi"},
             "requests": {"cpu": "100m", "memory": "128Mi"},
-        }
+        },
     }
 
 
@@ -80,10 +81,11 @@ def test_deserialization_imagepolicy(sample_connector_object_imagepolicy):
     assert crd.spec.image_policy.schedule == "0 2 * * *"
     assert crd.spec.image_policy.version == "0.1.x"
     assert crd.spec.container_extra == {
+        "env": [{"name": "MY_ENV_VAR", "value": "my_value"}],
         "resources": {
             "limits": {"cpu": "100m", "memory": "128Mi"},
             "requests": {"cpu": "100m", "memory": "128Mi"},
-        }
+        },
     }
 
 


### PR DESCRIPTION
## Related Tickets & Documents

Fixes #216 

## Changes

Allow `env` to be defind in `containerExtra` and merge it with the pod `env` we set in our code
