### PR TITLE
feat: Make TwingateConnector's containerExtra and podExtra mutable

### DIFF
--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -19,10 +19,6 @@ spec:
               x-kubernetes-validations:
                 - rule: (!has(oldSelf.id) || self.id == oldSelf.id)
                   message: "id is immutable once set"
-                - rule: (!has(oldSelf.containerExtra) || self.containerExtra == oldSelf.containerExtra)
-                  message: "containerExtra is immutable once set"
-                - rule: (!has(oldSelf.podExtra) || self.podExtra == oldSelf.podExtra)
-                  message: "podExtra is immutable once set"
                 - rule: (has(self.image) && !has(self.imagePolicy)) || (!has(self.image) && has(self.imagePolicy)) || (!has(self.image) && !has(self.imagePolicy))
                   message: "Can define either `image` or `imagePolicy`, not both."
               properties:

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -90,7 +90,7 @@ def test_connector_flows(run_kopf, ci_run_number):
         assert pod["metadata"]["ownerReferences"][0]["name"] == connector_name
         assert pod["metadata"]["ownerReferences"][0]["kind"] == "TwingateConnector"
 
-        # Check TwingateConnector update updates the pod
+        # Check patching TwingateConnector updates the pod
         kubectl_patch(
             f"tc/{connector_name}",
             {


### PR DESCRIPTION
## Related Tickets & Documents

Fixes #215 

## Changes

- Make `containerExtra` and `podExtra` mutable

The refactor in `TwingateConnector` reconciliation (https://github.com/Twingate/kubernetes-operator/pull/180) made this possible out of the box because we delete the pod and recreate it anyway on any update

