### PR TITLE
fix: Add validation for TwingateConnector when provider is “google”

### DIFF
--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -56,6 +56,9 @@ spec:
                     type: object
                     description: "ImagePolicy defines the image to use for the Connector and a schedule to keep it up to date."
                     required: ["provider"]
+                    x-kubernetes-validations:
+                      - rule: self.provider != "google" || (self.provider == "google" && !has(self.repository))
+                        message: "Google provider requires specifying repository."
                     properties:
                       provider:
                         type: string

--- a/tests_integration/test_crds_connector.py
+++ b/tests_integration/test_crds_connector.py
@@ -256,3 +256,23 @@ class TestConnectorCRD:
                         version: "^1.0.0"
                 """
             )
+
+    def test_google_provider_requires_repository(self, unique_connector_name):
+        with pytest.raises(subprocess.CalledProcessError) as ex:
+            kubectl_create(
+                f"""
+                apiVersion: twingate.com/v1beta
+                kind: TwingateConnector
+                metadata:
+                    name: {unique_connector_name}
+                spec:
+                    name: {unique_connector_name}
+                    logLevel: 3
+                    imagePolicy:
+                        provider: "google"
+                        version: "^1.0.0"
+                """
+            )
+
+        stderr = ex.value.stderr.decode()
+        assert "Google provider requires specifying repository." in stderr


### PR DESCRIPTION
## Related Tickets & Documents

Fixes #214 

## Changes

Added `TwingateConnector` CRD validation that forces defining `repository` if `provider` is `google`
