### PR TITLE
feat: TwingateConnector - allow defining extra pod annotations with `podAnnotations`

### DIFF
--- a/app/crds.py
+++ b/app/crds.py
@@ -305,6 +305,7 @@ class ConnectorSpec(BaseModel):
     image_policy: ConnectorImagePolicy | None = None
     container_extra: dict[str, Any] = {}
     pod_extra: dict[str, Any] = {}
+    pod_annotations: dict[str, Any] = {}
 
     remote_network_id: str = Field(
         default_factory=lambda: get_settings().remote_network_id

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -74,8 +74,9 @@ def get_connector_pod(
         ],
         **spec.pod_extra,
     }
+    pod_annotations = spec.pod_annotations.copy().update({ANNOTATION_POD_SPEC_VERSION: ANNOTATION_POD_SPEC_VERSION_VALUE})
 
-    pod_meta = V1ObjectMeta(annotations={ANNOTATION_POD_SPEC_VERSION: ANNOTATION_POD_SPEC_VERSION_VALUE})
+    pod_meta = V1ObjectMeta(annotations=pod_annotations)
 
     # fmt: on
     return kubernetes.client.V1Pod(spec=pod_spec, metadata=pod_meta)

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -74,7 +74,8 @@ def get_connector_pod(
         ],
         **spec.pod_extra,
     }
-    pod_annotations = spec.pod_annotations.copy().update({ANNOTATION_POD_SPEC_VERSION: ANNOTATION_POD_SPEC_VERSION_VALUE})
+    pod_annotations = spec.pod_annotations.copy()
+    pod_annotations.update({ANNOTATION_POD_SPEC_VERSION: ANNOTATION_POD_SPEC_VERSION_VALUE})
 
     pod_meta = V1ObjectMeta(annotations=pod_annotations)
 

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -74,8 +74,7 @@ def get_connector_pod(
         ],
         **spec.pod_extra,
     }
-    pod_annotations = spec.pod_annotations.copy()
-    pod_annotations.update({ANNOTATION_POD_SPEC_VERSION: ANNOTATION_POD_SPEC_VERSION_VALUE})
+    pod_annotations = spec.pod_annotations | {ANNOTATION_POD_SPEC_VERSION: ANNOTATION_POD_SPEC_VERSION_VALUE}
 
     pod_meta = V1ObjectMeta(annotations=pod_annotations)
 

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -85,6 +85,9 @@ spec:
                 podExtra:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                podAnnotations:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/examples/connector.yaml
+++ b/examples/connector.yaml
@@ -16,6 +16,8 @@ spec:
         cpu: 500m
         memory: 128Mi
   podExtra: {}
+  podAnnotations:
+    some/annotation: "some-value"
 ---
 apiVersion: twingate.com/v1beta
 kind: TwingateConnector
@@ -39,3 +41,5 @@ spec:
         cpu: 500m
         memory: 128Mi
   podExtra: {}
+  podAnnotations:
+    some/annotation: "some-value"

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -97,6 +97,7 @@ def test_connector_flows(run_kopf, ci_run_number):
                 "spec": {
                     "containerExtra": {"env": [{"name": "FOO", "value": "bar"}]},
                     "podExtra": {"restartPolicy": "OnFailure"},
+                    "podAnnotations": {"some/annotation": "some-value"},
                 }
             },
         )
@@ -107,6 +108,7 @@ def test_connector_flows(run_kopf, ci_run_number):
         assert pod["spec"]["restartPolicy"] == "OnFailure"
         assert pod["spec"]["containers"][0]["env"][-1]["name"] == "FOO"
         assert pod["spec"]["containers"][0]["env"][-1]["value"] == "bar"
+        assert pod["metadata"]["annotations"]["some/annotation"] == "some-value"
 
         kubectl_delete(f"tc/{connector_name}")
         time.sleep(10)


### PR DESCRIPTION
## Related Tickets & Documents

Fixes #217 

## Changes

- Add `podAnnotations` to `TwingateConnector` CRD
- propagate annotations to created pod
