### PR TITLE
feat: Add TwingateConnector sidecarContainers prop

### DIFF
--- a/app/crds.py
+++ b/app/crds.py
@@ -306,6 +306,7 @@ class ConnectorSpec(BaseModel):
     container_extra: dict[str, Any] = {}
     pod_extra: dict[str, Any] = {}
     pod_annotations: dict[str, Any] = {}
+    sidecar_containers: list[dict[str, Any]] = []
 
     remote_network_id: str = Field(
         default_factory=lambda: get_settings().remote_network_id

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -65,7 +65,8 @@ def get_connector_pod(
                     "runAsUser": 65532,
                },
                 **container_extra,
-            }
+            },
+            *spec.sidecar_containers,
         ],
         **spec.pod_extra,
     }

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -91,6 +91,11 @@ spec:
                 podAnnotations:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                sidecarContainers:
+                  type: array
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -93,6 +93,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 sidecarContainers:
                   type: array
+                  description: "SidecarContainers allows injecting additional containers to the Connector Pod."
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
## Related Tickets & Documents

Resolves #232

## Changes

Added `sidecarContainers` to allow injecting sidevcars to connector pods


## Notes

Example on prometheus operator: 
https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L3853

