### PR TITLE
feat: Added TwingateConnector `logAnalytics` flag

### DIFF
--- a/app/crds.py
+++ b/app/crds.py
@@ -300,7 +300,7 @@ class ConnectorSpec(BaseModel):
     id: str | None = None
     name: str | None = None
     log_level: int = 3
-    log_realtime_connections: bool = True
+    log_analytics: bool = True
     has_status_notifications_enabled: bool = True
     image: ConnectorImage | None = None
     image_policy: ConnectorImagePolicy | None = None

--- a/app/crds.py
+++ b/app/crds.py
@@ -300,6 +300,7 @@ class ConnectorSpec(BaseModel):
     id: str | None = None
     name: str | None = None
     log_level: int = 3
+    log_analytics: bool = True
     has_status_notifications_enabled: bool = True
     image: ConnectorImage | None = None
     image_policy: ConnectorImagePolicy | None = None

--- a/app/crds.py
+++ b/app/crds.py
@@ -300,7 +300,7 @@ class ConnectorSpec(BaseModel):
     id: str | None = None
     name: str | None = None
     log_level: int = 3
-    log_analytics: bool = True
+    log_realtime_connections: bool = True
     has_status_notifications_enabled: bool = True
     image: ConnectorImage | None = None
     image_policy: ConnectorImagePolicy | None = None

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -36,7 +36,7 @@ def get_connector_pod(
             },
         ]
 
-    if spec.log_analytics:
+    if spec.log_realtime_connections:
         connector_env_vars.append(
             {
                 "name": "TWINGATE_LOG_ANALYTICS",

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -36,7 +36,7 @@ def get_connector_pod(
             },
         ]
 
-    if spec.log_realtime_connections:
+    if spec.log_analytics:
         connector_env_vars.append(
             {
                 "name": "TWINGATE_LOG_ANALYTICS",

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -23,9 +23,9 @@ def get_connector_pod(
     spec = crd.spec
     name = crd.metadata.name
 
-    env_labels_version_policy = []
+    connector_env_vars = []
     if spec.image_policy:
-        env_labels_version_policy = [
+        connector_env_vars = [
             {
                 "name": "TWINGATE_LABEL_VERSION_POLICY_SCHEDULE",
                 "value": spec.image_policy.schedule,
@@ -35,6 +35,14 @@ def get_connector_pod(
                 "value": spec.image_policy.version,
             },
         ]
+
+    if spec.log_analytics:
+        connector_env_vars.append(
+            {
+                "name": "TWINGATE_LOG_ANALYTICS",
+                "value": "v2",
+            }
+        )
 
     container_extra = spec.container_extra
     extra_env = container_extra.pop("env", [])
@@ -49,7 +57,7 @@ def get_connector_pod(
                     {"name": "TWINGATE_LABEL_OPERATOR_VERSION", "value": get_version()},
                     {"name": "TWINGATE_URL", "value": tenant_url},
                     {"name": "TWINGATE_LOG_LEVEL", "value": str(spec.log_level)},
-                    *env_labels_version_policy,
+                    *connector_env_vars,
                     *extra_env
                 ],
                 "envFrom": [{"secretRef": {"name": name, "optional": False}}, *extra_env_from],

--- a/deploy/twingate-operator/Chart.yaml
+++ b/deploy/twingate-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: twingate-operator
 description: A Helm chart for installing twingate-operator
 type: application
-version: 0.1.6
+version: 0.1.7

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -36,6 +36,10 @@ spec:
                   minimum: -1
                   maximum: 7
                   description: "Log level for the Connector (-1 to 7: -1 for no logs, 0 - least verbose, 7 - most verbose, default: 3)."
+                logAnalytics:
+                  type: boolean
+                  default: true
+                  description: "Enabling real-time connection logs."
                 hasStatusNotificationsEnabled:
                   type: boolean
                   default: true

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -39,7 +39,7 @@ spec:
                 logAnalytics:
                   type: boolean
                   default: true
-                  description: "Enabling real-time connection logs."
+                  description: "Enable real-time connection logs."
                 hasStatusNotificationsEnabled:
                   type: boolean
                   default: true

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -36,7 +36,7 @@ spec:
                   minimum: -1
                   maximum: 7
                   description: "Log level for the Connector (-1 to 7: -1 for no logs, 0 - least verbose, 7 - most verbose, default: 3)."
-                logAnalytics:
+                logRealtimeConnections:
                   type: boolean
                   default: true
                   description: "Enabling real-time connection logs."

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -36,7 +36,7 @@ spec:
                   minimum: -1
                   maximum: 7
                   description: "Log level for the Connector (-1 to 7: -1 for no logs, 0 - least verbose, 7 - most verbose, default: 3)."
-                logRealtimeConnections:
+                logAnalytics:
                   type: boolean
                   default: true
                   description: "Enabling real-time connection logs."

--- a/tests_integration/test_crds_connector.py
+++ b/tests_integration/test_crds_connector.py
@@ -78,6 +78,7 @@ class TestConnectorCRD:
             },
             "spec": {
                 "logLevel": 4,
+                "logAnalytics": True,
                 "name": unique_connector_name,
                 "hasStatusNotificationsEnabled": True,
             },
@@ -155,6 +156,7 @@ class TestConnectorCRD:
             "spec": {
                 "hasStatusNotificationsEnabled": False,
                 "logLevel": 3,
+                "logAnalytics": True,
                 "name": unique_connector_name,
             },
         }
@@ -191,6 +193,7 @@ class TestConnectorCRD:
             "spec": {
                 "image": {"repository": "twingate/connector", "tag": "latest"},
                 "logLevel": 3,
+                "logAnalytics": True,
                 "hasStatusNotificationsEnabled": True,
                 "name": unique_connector_name,
             },
@@ -235,6 +238,7 @@ class TestConnectorCRD:
                 },
                 "name": unique_connector_name,
                 "logLevel": 3,
+                "logAnalytics": True,
                 "hasStatusNotificationsEnabled": True,
             },
         }

--- a/tests_integration/test_crds_connector.py
+++ b/tests_integration/test_crds_connector.py
@@ -78,7 +78,7 @@ class TestConnectorCRD:
             },
             "spec": {
                 "logLevel": 4,
-                "logRealtimeConnections": True,
+                "logAnalytics": True,
                 "name": unique_connector_name,
                 "hasStatusNotificationsEnabled": True,
             },
@@ -156,7 +156,7 @@ class TestConnectorCRD:
             "spec": {
                 "hasStatusNotificationsEnabled": False,
                 "logLevel": 3,
-                "logRealtimeConnections": True,
+                "logAnalytics": True,
                 "name": unique_connector_name,
             },
         }
@@ -193,7 +193,7 @@ class TestConnectorCRD:
             "spec": {
                 "image": {"repository": "twingate/connector", "tag": "latest"},
                 "logLevel": 3,
-                "logRealtimeConnections": True,
+                "logAnalytics": True,
                 "hasStatusNotificationsEnabled": True,
                 "name": unique_connector_name,
             },
@@ -238,7 +238,7 @@ class TestConnectorCRD:
                 },
                 "name": unique_connector_name,
                 "logLevel": 3,
-                "logRealtimeConnections": True,
+                "logAnalytics": True,
                 "hasStatusNotificationsEnabled": True,
             },
         }

--- a/tests_integration/test_crds_connector.py
+++ b/tests_integration/test_crds_connector.py
@@ -78,7 +78,7 @@ class TestConnectorCRD:
             },
             "spec": {
                 "logLevel": 4,
-                "logAnalytics": True,
+                "logRealtimeConnections": True,
                 "name": unique_connector_name,
                 "hasStatusNotificationsEnabled": True,
             },
@@ -156,7 +156,7 @@ class TestConnectorCRD:
             "spec": {
                 "hasStatusNotificationsEnabled": False,
                 "logLevel": 3,
-                "logAnalytics": True,
+                "logRealtimeConnections": True,
                 "name": unique_connector_name,
             },
         }
@@ -193,7 +193,7 @@ class TestConnectorCRD:
             "spec": {
                 "image": {"repository": "twingate/connector", "tag": "latest"},
                 "logLevel": 3,
-                "logAnalytics": True,
+                "logRealtimeConnections": True,
                 "hasStatusNotificationsEnabled": True,
                 "name": unique_connector_name,
             },
@@ -238,7 +238,7 @@ class TestConnectorCRD:
                 },
                 "name": unique_connector_name,
                 "logLevel": 3,
-                "logAnalytics": True,
+                "logRealtimeConnections": True,
                 "hasStatusNotificationsEnabled": True,
             },
         }


### PR DESCRIPTION
## Related Tickets & Documents

Resolves #238 

## Changes

- Added `logAnalytics` property to `TwingateConnector` (default to `true`)
- If `logAnalytics` is true we add `TWINGATE_LOG_ANALYTICS=v2` env var to connector pod
