### PR TITLE
feat: Don’t query for principal external ref once we have the id

### DIFF
--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -51,14 +51,6 @@ def check_status_created(status: dict | None) -> dict | None:
     return None
 
 
-@kopf.on.create("twingateresourceaccess")
-@kopf.on.update("twingateresourceaccess", field="spec")
-@kopf.timer(
-    "twingateresourceaccess",
-    interval=timedelta(seconds=10).seconds,
-    initial_delay=60,
-    idle=60,
-)
 def twingate_resource_access_create(body, spec, memo, logger, patch, status, **kwargs):
     logger.info("Got a TwingateResourceAccess create request: %s", spec)
     creation_status = check_status_created(status)
@@ -95,6 +87,16 @@ def twingate_resource_access_create(body, spec, memo, logger, patch, status, **k
             body, reason="Failure", message=f"{mex.mutation_name} failed: {mex.error}"
         )
         return fail(error=mex.error)
+
+
+kopf.on.create("twingateresourceaccess")(twingate_resource_access_create)
+kopf.on.update("twingateresourceaccess", field="spec")(twingate_resource_access_create)
+kopf.timer(
+    "twingateresourceaccess",
+    interval=timedelta(seconds=10).seconds,
+    initial_delay=60,
+    idle=60,
+)(twingate_resource_access_create)
 
 
 @kopf.on.delete("twingateresourceaccess")

--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -44,7 +44,8 @@ def get_principal_id(
 
 def check_status_created(status: dict | None) -> dict | None:
     if (
-        create_status := status and status.get("twingate_resource_access_create", {})
+        create_status := status
+        and status.get(twingate_resource_access_create.__name__, {})
     ) and create_status["success"]:
         return create_status
 

--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -22,8 +22,10 @@ def get_principal_id(
     if ref := access_crd.principal_external_ref:
         # Once `twingate_resource_access_create` ran and we have the principal_id
         # we dont use it and do not re-query the API
-        if create_status:
-            return create_status["principal_id"]
+        if principal_id_already_fetched := create_status and create_status.get(
+            "principal_id"
+        ):
+            return principal_id_already_fetched
 
         if ref.type == PrincipalTypeEnum.Group:
             principal_id = client.get_group_id(ref.name)
@@ -50,8 +52,17 @@ def check_status_created(status: dict | None) -> dict | None:
 
 
 @kopf.on.create("twingateresourceaccess")
-def twingate_resource_access_create(body, spec, memo, logger, patch, **kwargs):
+@kopf.on.update("twingateresourceaccess", field="spec")
+@kopf.timer(
+    "twingateresourceaccess",
+    interval=timedelta(seconds=10).seconds,
+    initial_delay=60,
+    idle=60,
+)
+def twingate_resource_access_create(body, spec, memo, logger, patch, status, **kwargs):
     logger.info("Got a TwingateResourceAccess create request: %s", spec)
+    creation_status = check_status_created(status)
+
     access_crd = ResourceAccessSpec(**spec)
     resource_crd = access_crd.get_resource()
     if not resource_crd:
@@ -65,7 +76,7 @@ def twingate_resource_access_create(body, spec, memo, logger, patch, **kwargs):
     resource_id = resource_crd.spec.id
     try:
         client = TwingateAPIClient(memo.twingate_settings)
-        principal_id = get_principal_id(access_crd, None, client)
+        principal_id = get_principal_id(access_crd, creation_status, client)
         client.resource_access_add(
             resource_id, principal_id, access_crd.security_policy_id
         )
@@ -86,38 +97,6 @@ def twingate_resource_access_create(body, spec, memo, logger, patch, **kwargs):
         return fail(error=mex.error)
 
 
-@kopf.on.update("twingateresourceaccess", field="spec")
-def twingate_resource_access_update(spec, diff, status, memo, logger, **kwargs):
-    logger.info(
-        "Got TwingateResourceAccess update request: %s. Diff: %s. Status: %s.",
-        spec,
-        diff,
-        status,
-    )
-    creation_status = check_status_created(status)
-    if not creation_status:
-        # Object didn't go through create yet?   wait...
-        raise kopf.TemporaryError("Resource not yet created, retrying...", delay=15)
-
-    # Note that both principalId/principalExternalRef and resourceRef are immutable so only securityPolicyId could
-    # change in this case we just need to call api_client.resource_access_add with the new value
-    access_crd = ResourceAccessSpec(**spec)
-    if resource_crd := access_crd.get_resource():
-        try:
-            client = TwingateAPIClient(memo.twingate_settings)
-            principal_id = get_principal_id(access_crd, creation_status, client)
-            client.resource_access_add(
-                resource_crd.spec.id,
-                principal_id,
-                access_crd.security_policy_id,
-            )
-            return success()
-        except GraphQLMutationError as mex:
-            return fail(error=mex.error)
-
-    return fail(error=f"Resource {access_crd.resource_ref_fullname} not found")
-
-
 @kopf.on.delete("twingateresourceaccess")
 def twingate_resource_access_delete(spec, status, memo, logger, **kwargs):
     logger.info("Got a TwingateResourceAccess delete request: %s", spec)
@@ -131,45 +110,3 @@ def twingate_resource_access_delete(spec, status, memo, logger, **kwargs):
         client = TwingateAPIClient(memo.twingate_settings)
         principal_id = get_principal_id(access_crd, creation_status, client)
         client.resource_access_remove(resource_id, principal_id)
-
-
-@kopf.timer(
-    "twingateresourceaccess",
-    interval=timedelta(hours=10).seconds,
-    initial_delay=60,
-    idle=60,
-)
-def twingate_resource_access_sync(body, spec, status, memo, logger, **kwargs):
-    creation_status = check_status_created(status)
-    if not creation_status:
-        return success(status="Skipped as creation didn't run yet.")
-
-    access_crd = ResourceAccessSpec(**spec)
-    resource_crd = access_crd.get_resource()
-    if not resource_crd:
-        err = f"Resource {access_crd.resource_ref_fullname} not found"
-        logger.warning(err)
-        kopf.warn(body, reason="ResourceNotFound", message=err)
-        return fail(error=err)
-
-    if not resource_crd.spec.id:
-        return success(status="Skipped as resource not yet created")
-
-    # Migrate old creation_status objects
-
-    try:
-        client = TwingateAPIClient(memo.twingate_settings)
-        principal_id = get_principal_id(access_crd, creation_status, client)
-
-        client.resource_access_add(
-            resource_crd.spec.id, principal_id, access_crd.security_policy_id
-        )
-
-        status["twingate_resource_access_create"]["principal_id"] = principal_id
-        status["twingate_resource_access_create"]["resource_id"] = resource_crd.spec.id
-        return success(principal_id=principal_id, resource_id=resource_crd.spec.id)
-    except GraphQLMutationError as mex:
-        kopf.exception(
-            body, reason="Failure", message=f"{mex.mutation_name} failed: {mex.error}"
-        )
-        return fail(error=mex.error)

--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -89,6 +89,7 @@ def twingate_resource_access_create(body, spec, memo, logger, patch, status, **k
         return fail(error=mex.error)
 
 
+# can't use decorator syntax because typecheck would fail (update has some extra params that we're not using)
 kopf.on.create("twingateresourceaccess")(twingate_resource_access_create)
 kopf.on.update("twingateresourceaccess", field="spec")(twingate_resource_access_create)
 kopf.timer(

--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -20,7 +20,7 @@ def get_principal_id(
         return principal_id
 
     if ref := access_crd.principal_external_ref:
-        # Once `twingate_resource_access_create` ran and we have the principal_id
+        # Once `twingate_resource_access_sync` ran and we have the principal_id
         # we dont use it and do not re-query the API
         if principal_id_already_fetched := create_status and create_status.get(
             "principal_id"
@@ -45,14 +45,14 @@ def get_principal_id(
 def check_status_created(status: dict | None) -> dict | None:
     if (
         create_status := status
-        and status.get(twingate_resource_access_create.__name__, {})
+        and status.get(twingate_resource_access_sync.__name__, {})
     ) and create_status["success"]:
         return create_status
 
     return None
 
 
-def twingate_resource_access_create(body, spec, memo, logger, patch, status, **kwargs):
+def twingate_resource_access_sync(body, spec, memo, logger, patch, status, **kwargs):
     logger.info("Got a TwingateResourceAccess create request: %s", spec)
     creation_status = check_status_created(status)
 
@@ -91,14 +91,14 @@ def twingate_resource_access_create(body, spec, memo, logger, patch, status, **k
 
 
 # can't use decorator syntax because typecheck would fail (update has some extra params that we're not using)
-kopf.on.create("twingateresourceaccess")(twingate_resource_access_create)
-kopf.on.update("twingateresourceaccess", field="spec")(twingate_resource_access_create)
+kopf.on.create("twingateresourceaccess")(twingate_resource_access_sync)
+kopf.on.update("twingateresourceaccess", field="spec")(twingate_resource_access_sync)
 kopf.timer(
     "twingateresourceaccess",
     interval=timedelta(seconds=10).seconds,
     initial_delay=60,
     idle=60,
-)(twingate_resource_access_create)
+)(twingate_resource_access_sync)
 
 
 @kopf.on.delete("twingateresourceaccess")

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -272,7 +272,7 @@ class TestResourceAccessUpdateHandler:
             "resourceRef": {"name": resource_spec.name},
             "principalId": "R3JvdXA6MTE1NzI2MA==",
         }
-        status = {"twingate_resource_access_create": {"ok": True}}
+        status = {"twingate_resource_access_create": {"success": True}}
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
@@ -301,7 +301,7 @@ class TestResourceAccessUpdateHandler:
             "resourceRef": {"name": "doesnt-exist"},
             "principalId": "R3JvdXA6MTE1NzI2MA==",
         }
-        status = {"twingate_resource_access_create": {"ok": True}}
+        status = {"twingate_resource_access_create": {"success": True}}
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
@@ -412,7 +412,7 @@ class TestResourceAccessSync:
 
         status = {
             "twingate_resource_access_create": {
-                "ok": True,
+                "success": True,
                 "principal_id": resource_access_spec["principalId"],
             }
         }
@@ -458,7 +458,7 @@ class TestResourceAccessSync:
 
         status = {
             "twingate_resource_access_create": {
-                "ok": True,
+                "success": True,
                 "principal_id": resource_access_spec["principalId"],
             }
         }
@@ -499,7 +499,7 @@ class TestResourceAccessSync:
 
         status = {
             "twingate_resource_access_create": {
-                "ok": True,
+                "success": True,
                 "principal_id": resource_access_spec["principalId"],
             }
         }
@@ -543,7 +543,7 @@ class TestResourceAccessSync:
 
         status = {
             "twingate_resource_access_create": {
-                "ok": True,
+                "success": True,
                 "principal_id": resource_access_spec["principalId"],
             }
         }

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -7,8 +7,8 @@ from app.api.client import GraphQLMutationError
 from app.crds import K8sMetadata
 from app.handlers.handlers_resource_access import (
     get_principal_id,
-    twingate_resource_access_create,
     twingate_resource_access_delete,
+    twingate_resource_access_sync,
 )
 
 
@@ -129,7 +129,7 @@ class TestResourceAccessCreateHandler:
             "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
             return_value=resource_crd_mock,
         ):
-            result = twingate_resource_access_create(
+            result = twingate_resource_access_sync(
                 body="",
                 spec=resource_access_spec,
                 memo=memo_mock,
@@ -171,7 +171,7 @@ class TestResourceAccessCreateHandler:
             return_value=None,
         ):
             with patch("kopf.warn") as kopf_warn_mock:
-                result = twingate_resource_access_create(
+                result = twingate_resource_access_sync(
                     body="",
                     spec=resource_access_spec,
                     memo=memo_mock,
@@ -213,7 +213,7 @@ class TestResourceAccessCreateHandler:
             "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
             return_value=resource_crd_mock,
         ), pytest.raises(kopf.TemporaryError):
-            twingate_resource_access_create(
+            twingate_resource_access_sync(
                 body="",
                 spec=resource_access_spec,
                 memo=memo_mock,
@@ -249,7 +249,7 @@ class TestResourceAccessCreateHandler:
             "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
             return_value=resource_crd_mock,
         ), patch("kopf.exception") as kopf_exception_mock:
-            result = twingate_resource_access_create(
+            result = twingate_resource_access_sync(
                 body="",
                 spec=resource_access_spec,
                 memo=memo_mock,
@@ -285,7 +285,7 @@ class TestResourceAccessDelete:
         resource_crd_mock.metadata = K8sMetadata(uid="uid", name="foo", namespace="bar")
 
         status = {
-            "twingate_resource_access_create": {
+            "twingate_resource_access_sync": {
                 "success": True,
                 "principal_id": resource_access_spec["principalId"],
             }
@@ -312,7 +312,7 @@ class TestResourceAccessDelete:
         logger_mock = MagicMock()
         memo_mock = MagicMock()
         status = {
-            "twingate_resource_access_create": {
+            "twingate_resource_access_sync": {
                 "success": True,
                 "principal_id": resource_access_spec["principalId"],
             }

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -311,13 +311,19 @@ class TestResourceAccessDelete:
 
         logger_mock = MagicMock()
         memo_mock = MagicMock()
+        status = {
+            "twingate_resource_access_create": {
+                "success": True,
+                "principal_id": resource_access_spec["principalId"],
+            }
+        }
 
         with patch(
             "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
             return_value=None,
         ):
             twingate_resource_access_delete(
-                resource_access_spec, {}, memo_mock, logger_mock
+                resource_access_spec, status, memo_mock, logger_mock
             )
 
         mock_api_client.resource_access_remove.assert_not_called()

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -98,7 +98,7 @@ class TestGetPrincipalId:
 
         expected = "success"
         principal_id = get_principal_id(
-            access_crd, {"principal_id": "success"}, mock_api_client
+            access_crd, {"principal_id": expected}, mock_api_client
         )
         assert principal_id == expected
 

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -410,6 +410,13 @@ class TestResourceAccessSync:
         resource_crd_mock.spec = resource_spec
         resource_crd_mock.metadata = K8sMetadata(uid="uid", name="foo", namespace="bar")
 
+        status = {
+            "twingate_resource_access_create": {
+                "ok": True,
+                "principal_id": resource_access_spec["principalId"],
+            }
+        }
+
         with patch(
             "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
             return_value=resource_crd_mock,
@@ -417,7 +424,7 @@ class TestResourceAccessSync:
             result = twingate_resource_access_sync(
                 body="",
                 spec=resource_access_spec,
-                status={},
+                status=status,
                 memo=memo_mock,
                 logger=logger_mock,
             )
@@ -425,6 +432,8 @@ class TestResourceAccessSync:
             assert result == {
                 "success": True,
                 "ts": ANY,
+                "principal_id": resource_access_spec["principalId"],
+                "resource_id": resource.id,
             }
 
     def test_sync_api_fails(self, resource_factory, mock_api_client):
@@ -447,6 +456,13 @@ class TestResourceAccessSync:
         resource_crd_mock.spec = resource_spec
         resource_crd_mock.metadata = K8sMetadata(uid="uid", name="foo", namespace="bar")
 
+        status = {
+            "twingate_resource_access_create": {
+                "ok": True,
+                "principal_id": resource_access_spec["principalId"],
+            }
+        }
+
         with patch(
             "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
             return_value=resource_crd_mock,
@@ -454,7 +470,7 @@ class TestResourceAccessSync:
             result = twingate_resource_access_sync(
                 body="",
                 spec=resource_access_spec,
-                status={},
+                status=status,
                 memo=memo_mock,
                 logger=logger_mock,
             )
@@ -481,6 +497,13 @@ class TestResourceAccessSync:
 
         expected_err = "Resource default/impossible not found"
 
+        status = {
+            "twingate_resource_access_create": {
+                "ok": True,
+                "principal_id": resource_access_spec["principalId"],
+            }
+        }
+
         with patch(
             "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
             return_value=None,
@@ -488,7 +511,7 @@ class TestResourceAccessSync:
             result = twingate_resource_access_sync(
                 body="",
                 spec=resource_access_spec,
-                status={},
+                status=status,
                 memo=memo_mock,
                 logger=logger_mock,
             )
@@ -518,6 +541,13 @@ class TestResourceAccessSync:
         resource_crd_mock.spec = resource_spec
         resource_crd_mock.metadata = K8sMetadata(uid="uid", name="foo", namespace="bar")
 
+        status = {
+            "twingate_resource_access_create": {
+                "ok": True,
+                "principal_id": resource_access_spec["principalId"],
+            }
+        }
+
         with patch(
             "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
             return_value=resource_crd_mock,
@@ -525,7 +555,7 @@ class TestResourceAccessSync:
             result = twingate_resource_access_sync(
                 body="",
                 spec=resource_access_spec,
-                status={},
+                status=status,
                 memo=memo_mock,
                 logger=logger_mock,
             )

--- a/tests_integration/test_resource_flows.py
+++ b/tests_integration/test_resource_flows.py
@@ -264,7 +264,7 @@ def test_resource_access_flows(
 
     # Create
     assert {
-        "message": "Handler 'twingate_resource_access_create' succeeded.",
+        "message": "Handler 'twingate_resource_access_sync' succeeded.",
         "timestamp": ANY,
         "object": {
             "apiVersion": "twingate.com/v1beta",


### PR DESCRIPTION
## Related Tickets & Documents

Resolves #239 

## Changes

- create\update\sync handler were all basically doing the same thing - removed redundant code and just use a single function
- When `principalExternalRef` is used - cache the resulting `principalId` on creation and use that value going forward
