### PR TITLE
feat: Ability to import existing twingate resources

### DIFF
--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -11,7 +11,17 @@ from app.handlers.base import fail, success
 def twingate_resource_create(body, spec, memo, logger, patch, **kwargs):
     logger.info("Got a create request: %s", spec)
     resource = ResourceSpec(**spec)
-    resource = TwingateAPIClient(memo.twingate_settings).resource_create(resource)
+    client = TwingateAPIClient(memo.twingate_settings)
+
+    # Support importing existing resources - if `id` already exist we assume it's already created
+    if resource.id:
+        resource = client.resource_update(resource)
+        return success(
+            twingate_id=resource.id,
+            message="Resource id already present - assuming an import of an existing resource.",
+        )
+
+    resource = client.resource_create(resource)
     patch.spec["id"] = resource.id
     kopf.info(body, reason="Success", message=f"Created on Twingate as {resource.id}")
     return success(

--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -18,6 +18,8 @@ def twingate_resource_create(body, spec, memo, logger, patch, **kwargs):
         resource = client.resource_update(resource)
         return success(
             twingate_id=resource.id,
+            created_at=resource.created_at.isoformat(),
+            updated_at=resource.updated_at.isoformat(),
             message="Resource id already present - assuming an import of an existing resource.",
         )
 

--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -16,6 +16,7 @@ def twingate_resource_create(body, spec, memo, logger, patch, **kwargs):
     # Support importing existing resources - if `id` already exist we assume it's already created
     if resource.id:
         resource = client.resource_update(resource)
+        kopf.info(body, reason="Success", message=f"Imported {resource.id}")
         return success(
             twingate_id=resource.id,
             created_at=resource.created_at.isoformat(),

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -71,6 +71,8 @@ class TestResourceCreateHandler:
         assert result == {
             "success": True,
             "twingate_id": resource.id,
+            "created_at": ANY,
+            "updated_at": ANY,
             "message": ANY,
             "ts": ANY,
         }

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -52,7 +52,9 @@ class TestResourceCreateHandler:
         )
         assert patch_mock.spec == {"id": resource.id}
 
-    def test_resource_import(self, resource_factory, kopf_info_mock, mock_api_client):
+    def test_when_id_is_specified_update_instead_of_create(
+        self, resource_factory, kopf_info_mock, mock_api_client
+    ):
         resource = resource_factory(id="pre-existing-id")
         resource_spec = resource.to_spec()
 

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -80,6 +80,10 @@ class TestResourceCreateHandler:
         mock_api_client.resource_update.assert_called_once_with(resource_spec)
         mock_api_client.resource_create.assert_not_called()
 
+        kopf_info_mock.assert_called_once_with(
+            "", reason="Success", message=f"Imported {resource.id}"
+        )
+
 
 class TestResourceUpdateHandler:
     def test_update(self, mock_api_client):

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -44,12 +44,39 @@ class TestResourceCreateHandler:
             "ts": ANY,
         }
 
+        mock_api_client.resource_update.assert_not_called()
         mock_api_client.resource_create.assert_called_once_with(resource_spec)
         logger_mock.info.assert_called_once_with("Got a create request: %s", spec)
         kopf_info_mock.assert_called_once_with(
             "", reason="Success", message=f"Created on Twingate as {resource.id}"
         )
         assert patch_mock.spec == {"id": resource.id}
+
+    def test_resource_import(self, resource_factory, kopf_info_mock, mock_api_client):
+        resource = resource_factory(id="pre-existing-id")
+        resource_spec = resource.to_spec()
+
+        spec = resource_spec.model_dump(by_alias=True)
+
+        logger_mock = MagicMock()
+        memo_mock = MagicMock()
+        patch_mock = MagicMock()
+        patch_mock.spec = {}
+
+        mock_api_client.resource_update.return_value = resource
+
+        result = twingate_resource_create(
+            body="", spec=spec, memo=memo_mock, logger=logger_mock, patch=patch_mock
+        )
+        assert result == {
+            "success": True,
+            "twingate_id": resource.id,
+            "message": ANY,
+            "ts": ANY,
+        }
+
+        mock_api_client.resource_update.assert_called_once_with(resource_spec)
+        mock_api_client.resource_create.assert_not_called()
 
 
 class TestResourceUpdateHandler:


### PR DESCRIPTION
## Related Tickets & Documents

Resolves #245 

## Changes

- If `TwingateResource` created with `id` dont attempt to create it
