### PR TITLE
feat: Allow defining custom resource Name for annotated service resource

### DIFF
--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -22,6 +22,7 @@ def k8s_get_twingate_resource(
 
 
 ALLOWED_EXTRA_ANNOTATIONS: list[tuple[str, Callable]] = [
+    ("name", str),
     ("alias", str),
     ("isBrowserShortcutEnabled", to_bool),
     ("securityPolicyId", str),

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -87,6 +87,7 @@ class TestServiceToTwingateResource:
         }
 
         expected_annotation_values = {
+            "name": "my resource",
             "alias": "myapp.internal",
             "isBrowserShortcutEnabled": True,
             "securityPolicyId": "12345",

--- a/tests_integration/test_service_flows.py
+++ b/tests_integration/test_service_flows.py
@@ -87,7 +87,7 @@ def test_service_flows(kopf_runner_args, kopf_settings, ci_run_number):
             "id": ANY,
             "isBrowserShortcutEnabled": False,
             "isVisible": True,
-            "name": f"{service_name}-resource",
+            "name": "My Service",
             "protocols": {
                 "allowIcmp": False,
                 "tcp": {

--- a/tests_integration/test_service_flows.py
+++ b/tests_integration/test_service_flows.py
@@ -23,6 +23,7 @@ def test_service_flows(kopf_runner_args, kopf_settings, ci_run_number):
           name: {service_name}
           annotations:
             twingate.com/resource: "true"
+            twingate.com/resource-name: "My Service"
             twingate.com/resource-alias: "myapp.internal"
             twingate.com/resource-isVisible: "true"
             twingate.com/resource-isBrowserShortcutEnabled: "false"
@@ -53,7 +54,7 @@ def test_service_flows(kopf_runner_args, kopf_settings, ci_run_number):
             "id": ANY,
             "isBrowserShortcutEnabled": False,
             "isVisible": True,
-            "name": f"{service_name}-resource",
+            "name": "My Service",
             "protocols": {
                 "allowIcmp": False,
                 "tcp": {"policy": "RESTRICTED", "ports": [{"end": 80, "start": 80}]},


### PR DESCRIPTION
## Related Tickets & Documents

Related to comments mentioned in #271 

## Changes

- Allow overriding default resource name with a `twingate.com/resource-name` annotation
