### PR TITLE
fix: Remove TwingateResourceAccess ownerReference

### DIFF
--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -81,9 +81,6 @@ def twingate_resource_access_change(body, spec, memo, logger, patch, status, **k
             reason="Success",
             message=f"Added access to {resource_crd.spec.id}<>{principal_id}",
         )
-        patch.metadata["ownerReferences"] = [
-            resource_crd.metadata.owner_reference_object
-        ]
         return success(principal_id=principal_id, resource_id=resource_id)
     except GraphQLMutationError as mex:
         kopf.exception(

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -119,7 +119,6 @@ class TestResourceAccessChangeHandler:
         memo_mock = MagicMock()
         patch_mock = MagicMock()
         patch_mock.metadata = {}
-        patch_mock.metadata["ownerReferences"] = []
 
         resource_crd_mock = MagicMock()
         resource_crd_mock.spec = resource_spec
@@ -145,14 +144,6 @@ class TestResourceAccessChangeHandler:
             }
 
         kopf_info_mock.assert_called_once_with("", reason="Success", message=ANY)
-        assert patch_mock.metadata["ownerReferences"] == [
-            {
-                "apiVersion": "twingate.com/v1",
-                "kind": "TwingateResource",
-                "name": "foo",
-                "uid": "uid",
-            }
-        ]
 
     def test_create_invalid_ref(self, mock_api_client):
         resource_access_spec = {


### PR DESCRIPTION
## Related Tickets & Documents

Fix #287 

## Changes

- Remove ownerReference for `TwingateResourceAccess` 

If a resource that the access object is referencing gets removed the access object shouldnt get deleted as well but remain there and log errors on reconciliation
