### PR TITLE
fix: Allow connectors to run under Restricted pod-security policy

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -71,6 +71,9 @@ def get_connector_pod(
                     },
                     "runAsNonRoot": True,
                     "runAsUser": 65532,
+                    "seccompProfile": {
+                        "type": "RuntimeDefault"
+                    },
                },
                 **container_extra,
             },

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -53,8 +53,6 @@ securityContext:
   runAsNonRoot: true
   allowPrivilegeEscalation: false
   runAsUser: 1000
-  seccompProfile:
-    type: RuntimeDefault
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -46,13 +46,15 @@ podSecurityContext:
     type: RuntimeDefault
 
 securityContext:
-   capabilities:
-     drop:
-     - ALL
-   readOnlyRootFilesystem: true
-   runAsNonRoot: true
-   allowPrivilegeEscalation: false
-   runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Related Tickets & Documents

Resolves #102 

## Changes
When testing setting pod-security to restricted
```
kubectl label --dry-run=server --overwrite ns twingate \
   pod-security.kubernetes.io/enforce=restricted \
   pod-security.kubernetes.io/enforce-version=latest
Warning: existing pods in namespace "twingate" violate the new PodSecurity enforce level "restricted:latest"
Warning: corp-connector-stg-1 (and 1 other pod): seccompProfile
namespace/twingate labeled (server dry run)
```

connectors are missing seccompProfile

Add required 
```
  seccompProfile:
    type: RuntimeDefault
```
