### PR TITLE
Removes 'nullable: false' from CRD definitions (as its the default)

### DIFF
--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -27,7 +27,6 @@ spec:
                   nullable: true
                 name:
                   type: string
-                  nullable: false
                   maxLength: 30
                   description: "Name of the Connector (optional, if not specified Twingate will give a random name)"
                 logLevel:
@@ -76,11 +75,9 @@ spec:
                         description: "Repository to check for new versions tags."
                       schedule:
                         type: string
-                        nullable: false
                         description: "Cron schedule to check for new versions."
                       version:
                         type: string
-                        nullable: false
                         description: "Semver version specifier (ex: '^1.0.0'). Uses NPM spec: https://github.com/npm/node-semver#ranges"
                       allowPrerelease:
                         type: boolean

--- a/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
@@ -24,7 +24,6 @@ spec:
               properties:
                 principalId:
                   type: string
-                  nullable: False
                   pattern: "^[-A-Za-z0-9+/]*={0,3}$"
                   description: "principalId is the ID of the principal to provide access to the resource."
                   x-kubernetes-validations:
@@ -32,7 +31,6 @@ spec:
                       message: "principalId is immutable"
                 principalExternalRef:
                   type: object
-                  nullable: False
                   required: ["type", "name"]
                   properties:
                     type:
@@ -46,7 +44,6 @@ spec:
                           message: "principalExternalRef.type is immutable"
                     name:
                       type: string
-                      nullable: False
                       description: "Name of the external reference to match. (Note: name uniqueness is not enforce, if 2 entities match the same name, the first will be used)"
                       x-kubernetes-validations:
                         - rule: self == oldSelf
@@ -57,7 +54,6 @@ spec:
                   pattern: "^[-A-Za-z0-9+/]*={0,3}$"
                 resourceRef:
                   type: object
-                  nullable: False
                   description: "resourceRef specifies the TwingateResource reference to provide access to."
                   x-kubernetes-validations:
                     - rule: self == oldSelf
@@ -65,7 +61,6 @@ spec:
                   properties:
                     name:
                       type: string
-                      nullable: false
                       description: "Name of the resource."
                     namespace:
                       type: string

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -26,11 +26,9 @@ spec:
                   nullable: true
                 name:
                   type: string
-                  nullable: false
                   description: "Name of the resource."
                 address:
                   type: string
-                  nullable: false
                   description: "Address of the resource."
                 alias:
                   type: string
@@ -82,12 +80,10 @@ spec:
                              properties:
                                start:
                                  type: integer
-                                 nullable: false
                                  minimum: 1
                                  maximum: 65535
                                end:
                                  type: integer
-                                 nullable: false
                                  minimum: 1
                                  maximum: 65535
                     udp:
@@ -115,12 +111,10 @@ spec:
                              properties:
                                start:
                                  type: integer
-                                 nullable: false
                                  minimum: 1
                                  maximum: 65535
                                end:
                                  type: integer
-                                 nullable: false
                                  minimum: 1
                                  maximum: 65535
             status:


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #343 

## Changes

- Remove included explicit definition of `nullable: false` from the CRDs as its the Kubernetes default, and won't be persisted in the representation of the CRD resource.


## Notes

The goal here is for any gitops flow to not always detect a "drift" or "dirtiness" between what is in code, and what is available via the Kubernetes API.
