### PR TITLE
feat: Nicer `kubectl get` for TwingateResource and TwingateConnector

### DIFF
--- a/deploy/twingate-operator/Chart.yaml
+++ b/deploy/twingate-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: twingate-operator
 description: A Helm chart for installing twingate-operator
 type: application
-version: 0.1.7
+version: 0.1.8

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -101,6 +101,18 @@ spec:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: ID
+          type: string
+          description: "The ID of the connector."
+          jsonPath: .spec.id
+        - name: Display Name
+          type: string
+          description: "Name of the connector."
+          jsonPath: .spec.name
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
   scope: Namespaced
   names:
     plural: twingateconnectors

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -120,6 +120,26 @@ spec:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: ID
+          type: string
+          description: "The ID of the resource."
+          jsonPath: .spec.id
+        - name: Display Name
+          type: string
+          description: "Name of the resource."
+          jsonPath: .spec.name
+        - name: Address
+          type: string
+          description: "Address of the resource."
+          jsonPath: .spec.address
+        - name: Alias
+          type: string
+          description: "Alias of the resource."
+          jsonPath: .spec.alias
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
   scope: Namespaced
   names:
     plural: twingateresources


### PR DESCRIPTION
## Changes

Added `additionalPrinterColumns` section to the Connector and Resource CRDs.


## Notes

See docs: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#additional-printer-columns