### PR TITLE
feat: Support referencing TwingateGroup from TwingateResourceAccess

### DIFF
--- a/app/crds.py
+++ b/app/crds.py
@@ -55,6 +55,11 @@ class BaseK8sModel(BaseModel):
     status: dict[str, Any] | None = None
 
 
+class _KubernetesObjectRef(BaseModel):
+    name: str
+    namespace: str = Field(default="default")
+
+
 # region TwingateResourceCRD
 
 
@@ -151,11 +156,6 @@ class PrincipalTypeEnum(str, Enum):
     ServiceAccount = "serviceAccount"
 
 
-class _ResourceRef(BaseModel):
-    name: str
-    namespace: str = Field(default="default")
-
-
 class _PrincipalExternalRef(BaseModel):
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
 
@@ -166,17 +166,18 @@ class _PrincipalExternalRef(BaseModel):
 class ResourceAccessSpec(BaseModel):
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
 
-    resource_ref: _ResourceRef
+    resource_ref: _KubernetesObjectRef
     principal_id: str | None = None
+    group_ref: _KubernetesObjectRef | None = None
     principal_external_ref: _PrincipalExternalRef | None = None
     security_policy_id: str | None = None
 
     @model_validator(mode="after")
-    def validate_princiapl_id_or_principal_external_ref(self):
-        if self.principal_id or self.principal_external_ref:
+    def validate_target_ref_exists(self):
+        if self.principal_id or self.group_ref or self.principal_external_ref:
             return self
 
-        raise ValueError("Missing principal_id or principal_external_ref")
+        raise ValueError("Missing principal_id, group_ref or principal_external_ref")
 
     @property
     def resource_ref_fullname(self) -> str:

--- a/app/handlers/handlers_groups.py
+++ b/app/handlers/handlers_groups.py
@@ -1,3 +1,4 @@
+import os
 from datetime import timedelta
 
 import kopf
@@ -49,8 +50,15 @@ def twingate_group_create_update(body, spec, logger, memo, patch, **kwargs):
     )
 
 
+GROUP_RECONCILER_INTERVAL = int(os.environ.get("GROUP_RECONCILER_INTERVAL", timedelta(hours=10).seconds))  # fmt: skip
+GROUP_RECONCILER_INIT_DELAY = int(os.environ.get("GROUP_RECONCILER_INIT_DELAY", 60))  # fmt: skip
+
+
 @kopf.timer(
-    "twingategroup", interval=timedelta(hours=10).seconds, initial_delay=60, idle=60
+    "twingategroup",
+    interval=GROUP_RECONCILER_INTERVAL,
+    initial_delay=GROUP_RECONCILER_INIT_DELAY,
+    idle=60,
 )
 def twingate_group_reconciler(body, spec, logger, memo, patch, **_):
     return twingate_group_create_update(body, spec, logger, memo, patch)

--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -19,6 +19,15 @@ def get_principal_id(
     if principal_id := access_crd.principal_id:
         return principal_id
 
+    if group_ref_object := access_crd.get_group_ref_object():
+        group_spec = group_ref_object["spec"]
+        if group_id := group_spec.get("id"):
+            return group_id
+
+        raise kopf.TemporaryError(
+            "TwingateGroup object doesn't have an id yet. retrying...", delay=15
+        )
+
     if ref := access_crd.principal_external_ref:
         # Once `twingate_resource_access_change` ran and we have the principal_id
         # we dont use it and do not re-query the API

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -32,6 +32,7 @@ class TestGetPrincipalId:
         access_crd = MagicMock()
         access_crd.principal_id = None
         access_crd.principal_external_ref = None
+        access_crd.get_group_ref_object.return_value = None
         with pytest.raises(
             ValueError, match="Missing principal_id or principal_external_ref"
         ):
@@ -40,6 +41,7 @@ class TestGetPrincipalId:
     def test_from_external_ref_group(self, mock_api_client):
         access_crd = MagicMock()
         access_crd.principal_id = None
+        access_crd.get_group_ref_object.return_value = None
         access_crd.principal_external_ref = MagicMock()
         access_crd.principal_external_ref.type = "group"
         access_crd.principal_external_ref.name = "group-name"
@@ -54,6 +56,7 @@ class TestGetPrincipalId:
     def test_from_external_ref_sa(self, mock_api_client):
         access_crd = MagicMock()
         access_crd.principal_id = None
+        access_crd.get_group_ref_object.return_value = None
         access_crd.principal_external_ref = MagicMock()
         access_crd.principal_external_ref.type = "serviceAccount"
         access_crd.principal_external_ref.name = "sa-name"
@@ -68,6 +71,7 @@ class TestGetPrincipalId:
     def test_from_external_ref_returns_none(self, mock_api_client):
         access_crd = MagicMock()
         access_crd.principal_id = None
+        access_crd.get_group_ref_object.return_value = None
         access_crd.principal_external_ref = MagicMock()
         access_crd.principal_external_ref.type = "serviceAccount"
         access_crd.principal_external_ref.name = "sa-name"
@@ -82,6 +86,7 @@ class TestGetPrincipalId:
     def test_from_external_ref_invalid_type_returns_none(self, mock_api_client):
         access_crd = MagicMock()
         access_crd.principal_id = None
+        access_crd.get_group_ref_object.return_value = None
         access_crd.principal_external_ref = MagicMock()
         access_crd.principal_external_ref.type = "invalid"
         access_crd.principal_external_ref.name = "sa-name"
@@ -92,6 +97,7 @@ class TestGetPrincipalId:
     def test_from_external_ref_uses_created_status_principal_id(self):
         access_crd = MagicMock()
         access_crd.principal_id = None
+        access_crd.get_group_ref_object.return_value = None
         access_crd.principal_external_ref = MagicMock()
         access_crd.principal_external_ref.type = "invalid"
         access_crd.principal_external_ref.name = "sa-name"

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -38,6 +38,21 @@ class TestGetPrincipalId:
         ):
             get_principal_id(access_crd, None, MagicMock())
 
+    def test_id_from_group_ref_object(self):
+        access_crd = MagicMock()
+        access_crd.principal_id = None
+        access_crd.principal_external_ref = None
+        access_crd.get_group_ref_object.return_value = {"spec": {"id": "group-id"}}
+        assert get_principal_id(access_crd, None, MagicMock()) == "group-id"
+
+    def test_id_from_group_ref_object_not_ready_raises_temoraryerror(self):
+        access_crd = MagicMock()
+        access_crd.principal_id = None
+        access_crd.principal_external_ref = None
+        access_crd.get_group_ref_object.return_value = {"spec": {"id": None}}
+        with pytest.raises(kopf.TemporaryError):
+            assert get_principal_id(access_crd, None, MagicMock()) == "group-id"
+
     def test_from_external_ref_group(self, mock_api_client):
         access_crd = MagicMock()
         access_crd.principal_id = None

--- a/app/tests/test_crds_resourceaccess.py
+++ b/app/tests/test_crds_resourceaccess.py
@@ -161,6 +161,68 @@ def test_deserialization(sample_resourceaccess_object):
     assert crd.spec.resource_ref_fullname == "default/foo"
 
 
+def test_deserialization_with_group_ref():
+    data = {
+        "apiVersion": "twingate.com/v1",
+        "kind": "TwingateResourceAccess",
+        "metadata": {
+            "creationTimestamp": "2023-09-29T19:30:39Z",
+            "finalizers": ["kopf.zalando.org/KopfFinalizerMarker"],
+            "generation": 1,
+            "managedFields": [
+                {
+                    "apiVersion": "twingate.com/v1",
+                    "fieldsType": "FieldsV1",
+                    "fieldsV1": {
+                        "f:metadata": {
+                            "f:finalizers": {
+                                ".": {},
+                                'v:"kopf.zalando.org/KopfFinalizerMarker"': {},
+                            }
+                        }
+                    },
+                    "manager": "kopf",
+                    "operation": "Update",
+                    "time": "2023-09-29T19:30:39Z",
+                },
+                {
+                    "apiVersion": "twingate.com/v1",
+                    "fieldsType": "FieldsV1",
+                    "fieldsV1": {
+                        "f:spec": {
+                            ".": {},
+                            "f:principalId": {},
+                            "f:resourceRef": {".": {}, "f:name": {}, "f:namespace": {}},
+                        }
+                    },
+                    "manager": "kubectl-create",
+                    "operation": "Update",
+                    "time": "2023-09-29T19:30:39Z",
+                },
+            ],
+            "name": "foo-access-to-bar",
+            "namespace": "default",
+            "resourceVersion": "612168",
+            "uid": "ad0298c5-b84f-4617-b4a2-d3cbbe9f6a4c",
+        },
+        "spec": {
+            "resourceRef": {"name": "foo", "namespace": "default"},
+            "groupRef": {
+                "name": "test-group",
+                "namespace": "myns",
+            },
+        },
+    }
+    crd = TwingateResourceAccessCRD(**data)
+    assert crd.spec.group_ref.namespace == "myns"
+    assert crd.spec.group_ref.name == "test-group"
+    assert crd.spec.resource_ref.name == "foo"
+    assert crd.spec.resource_ref.namespace == "default"
+    assert crd.metadata.name == "foo-access-to-bar"
+    assert crd.metadata.uid == "ad0298c5-b84f-4617-b4a2-d3cbbe9f6a4c"
+    assert crd.spec.resource_ref_fullname == "default/foo"
+
+
 def test_deserialization_with_principal_external_ref():
     data = {
         "apiVersion": "twingate.com/v1",
@@ -220,6 +282,9 @@ def test_deserialization_with_principal_external_ref():
     assert crd.spec.resource_ref_fullname == "default/foo"
 
 
+# region get_resource
+
+
 def test_spec_get_resource_ref_object(
     mock_get_namespaced_custom_object, sample_resourceaccess_object
 ):
@@ -274,3 +339,6 @@ def test_spec_get_resource_failure_returns_none(
     crd = TwingateResourceAccessCRD(**sample_resourceaccess_object)
     response = crd.spec.get_resource()
     assert response is None
+
+
+# endregion

--- a/app/tests/test_crds_resourceaccess.py
+++ b/app/tests/test_crds_resourceaccess.py
@@ -100,6 +100,45 @@ def sample_resource_object():
 
 
 @pytest.fixture
+def sample_group_object():
+    return {
+        "apiVersion": "twingate.com/v1beta",
+        "kind": "TwingateGroup",
+        "metadata": {
+            "annotations": {
+                "kubectl.kubernetes.io/last-applied-configuration": '{"apiVersion":"twingate.com/v1beta","kind":"TwingateGroup","metadata":{"annotations":{},"name":"example","namespace":"default"},"spec":{"members":["eran@twingate.com"],"name":"Example Group"}}\n',
+                "twingate.com/kopf-managed": "yes",
+                "twingate.com/last-handled-configuration": '{"spec":{"id":"R3JvdXA6MjAxNjc5MA==","name":"Example Group"}}\n',
+            },
+            "creationTimestamp": "2024-07-24T22:51:32Z",
+            "finalizers": ["twingate.com/finalizer"],
+            "generation": 31,
+            "name": "example",
+            "namespace": "default",
+            "resourceVersion": "9848778",
+            "uid": "da2bd676-3e9e-4162-b203-bced1d27385e",
+        },
+        "spec": {"id": "R3JvdXA6MjAxNjc5MA==", "name": "Example Group"},
+        "status": {
+            "twingate": {"progress": {}},
+            "twingate_group_create_update": {
+                "success": True,
+                "ts": "2024-09-19T17:53:16.460069",
+                "twingate_id": "R3JvdXA6MjAxNjc5MA==",
+            },
+            "twingate_group_reconciler": {
+                "message": "Group reconciled",
+                "success": True,
+                "ts": "2024-09-19T17:54:16.494586",
+                "twingate_id": "R3JvdXA6MjAxNjc5MA==",
+            },
+            "user_ids": [{"email": "eran@twingate.com", "id": "VXNlcjoxMTYwMDA="}],
+            "user_ids_hash": "eaa47aed357c554764003095d6656f49",
+        },
+    }
+
+
+@pytest.fixture
 def sample_resourceaccess_object():
     return {
         "apiVersion": "twingate.com/v1",
@@ -339,6 +378,26 @@ def test_spec_get_resource_failure_returns_none(
     crd = TwingateResourceAccessCRD(**sample_resourceaccess_object)
     response = crd.spec.get_resource()
     assert response is None
+
+
+# endregion
+
+
+# region get_group_ref_object
+def test_spec_get_group_ref_object(
+    mock_get_namespaced_custom_object, sample_resourceaccess_object, sample_group_object
+):
+    resource_access_object = sample_resourceaccess_object
+    del sample_resourceaccess_object["spec"]["principalId"]
+    sample_resourceaccess_object["spec"]["groupRef"] = {
+        "name": sample_group_object["metadata"]["name"],
+        "namespace": sample_group_object["metadata"]["namespace"],
+    }
+
+    mock_get_namespaced_custom_object.return_value = sample_group_object
+    crd = TwingateResourceAccessCRD(**resource_access_object)
+    response = crd.spec.get_group_ref_object()
+    assert response == sample_group_object
 
 
 # endregion

--- a/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
@@ -21,6 +21,8 @@ spec:
                   required: ["resourceRef", "principalId"]
                 - properties:
                   required: ["resourceRef", "principalExternalRef"]
+                - properties:
+                  required: ["resourceRef", "groupRef"]
               properties:
                 principalId:
                   type: string
@@ -29,6 +31,20 @@ spec:
                   x-kubernetes-validations:
                     - rule: self == oldSelf
                       message: "principalId is immutable"
+                groupRef:
+                  type: object
+                  description: "groupRef specifies the TwingateGroup kubernetes object reference to provide access to."
+                  x-kubernetes-validations:
+                    - rule: self == oldSelf
+                      message: "groupRef is immutable."
+                  properties:
+                    name:
+                      type: string
+                      description: "Name of the TwingateGroup object."
+                    namespace:
+                      type: string
+                      default: default
+                      description: "Namespace of TwingateGroup object."
                 principalExternalRef:
                   type: object
                   required: ["type", "name"]

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -42,7 +42,7 @@ def run_kopf(kopf_runner_args, kopf_settings):
 def random_connector_name(ci_run_number):
     def generate(prefix: str) -> str:
         random_str = "".join(
-            random.choices(string.ascii_uppercase + string.digits, k=8)  # noqa:S311
+            random.choices(string.ascii_lowercase + string.digits, k=8)  # noqa:S311
         )
         result = f"{prefix}-{ci_run_number}-{random_str}"
         assert len(result) <= 30

--- a/tests_integration/test_resource_flows.py
+++ b/tests_integration/test_resource_flows.py
@@ -258,7 +258,13 @@ def test_resource_access_flows(
     )
 
     # fmt: off
-    with KopfRunner(kopf_runner_args, settings=kopf_settings) as runner:
+    with KopfRunner(kopf_runner_args,
+                    settings=kopf_settings,
+                    env={
+                        "GROUP_RECONCILER_INTERVAL": "1",
+                        "GROUP_RECONCILER_INIT_DELAY": "1",
+                    },
+    ) as runner:
         kubectl_create(RESOURCE_OBJ)
         kubectl_create(GROUP_OBJ)
         time.sleep(5)  # give it some time to react

--- a/tests_integration/test_resource_flows.py
+++ b/tests_integration/test_resource_flows.py
@@ -201,15 +201,27 @@ ACCESS_OBJECTS = {
             type: serviceAccount
             name: "{principal_name}"
     """,
+    "OBJ_ACCESS_BY_GROUPREF": """
+        apiVersion: twingate.com/v1beta
+        kind: TwingateResourceAccess
+        metadata:
+          name: {resource_name}
+        spec:
+          resourceRef:
+            name: {resource_name}
+          groupRef:
+            name: "test-group"
+    """,
 }
 
 
 @pytest.mark.parametrize(
     "access_object_yaml_tmpl_name",
     [
-        "OBJ_ACCESS_BY_PRINCIPAL_ID",
-        "OBJ_ACCESS_BY_PRINCIPAL_NAME_GROUP",
-        "OBJ_ACCESS_BY_PRINCIPAL_NAME_SA",
+        # "OBJ_ACCESS_BY_PRINCIPAL_ID",
+        # "OBJ_ACCESS_BY_PRINCIPAL_NAME_GROUP",
+        # "OBJ_ACCESS_BY_PRINCIPAL_NAME_SA",
+        "OBJ_ACCESS_BY_GROUPREF",
     ],
 )
 def test_resource_access_flows(
@@ -229,6 +241,15 @@ def test_resource_access_flows(
           address: my.default.cluster.local
     """
 
+    GROUP_OBJ = """
+        apiVersion: twingate.com/v1beta
+        kind: TwingateGroup
+        metadata:
+          name: test-group
+        spec:
+            name: Test Group
+    """
+
     access_object_yaml_tmpl = ACCESS_OBJECTS[access_object_yaml_tmpl_name]
     access_object_yaml = access_object_yaml_tmpl.format(
         resource_name=unique_resource_name,
@@ -239,6 +260,7 @@ def test_resource_access_flows(
     # fmt: off
     with KopfRunner(kopf_runner_args, settings=kopf_settings) as runner:
         kubectl_create(RESOURCE_OBJ)
+        kubectl_create(GROUP_OBJ)
         time.sleep(5)  # give it some time to react
 
         kubectl_create(access_object_yaml)
@@ -251,6 +273,7 @@ def test_resource_access_flows(
         time.sleep(1)  # give it some time to react
 
         kubectl(f"delete tgr/{unique_resource_name}")
+        kubectl("delete tgg/test-group")
 
         time.sleep(5)  # give it some time to react
 


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #364 

## Changes

- Added `groupRef` to `TwingateResourceAccess` CRD
- Some improvement to integration test - when re-run from failed, the CI run number doesnt change which caused re-runs to not work. So added better randomization for resource names to allow rerunning


Usage Example:
```
apiVersion: twingate.com/v1beta
kind: TwingateResource
metadata:
  name: my-twingate-resource
spec:
  name: My K8S Resource
  address: my.default.cluster.local
  alias: mine.local
---
apiVersion: twingate.com/v1beta
kind: TwingateGroup
metadata:
  name: test-group
spec:
    name: Test Group
---
apiVersion: twingate.com/v1beta
kind: TwingateResourceAccess
metadata:
  name: my-twingate-resource
spec:
  resourceRef:
    name: my-twingate-resource
  groupRef:
    name: "test-group"
```
