### PR TITLE
fix: TwingateResourceAccess deletion fail if resource has been deleted

### DIFF
--- a/app/api/tests/test_client_resource_access.py
+++ b/app/api/tests/test_client_resource_access.py
@@ -90,7 +90,46 @@ class TestResourceAccessAPIs:
             resource_id=resource_id, principal_id=principal_id
         )
 
-    def test_resource_access_remove_failure(
+    def test_resource_access_remove_invalid_id_returns_false(
+        self, test_url, api_client, mocked_responses
+    ):
+        resource_id = "test-resource"
+        principal_id = "test-principal"
+
+        expected_variables = {"resourceId": resource_id, "principalId": principal_id}
+
+        failed_response = """
+                    {
+                      "errors": [
+                        {
+                          "message": "{'id': ['Unable to parse global ID']}",
+                          "locations": [{"line": 2, "column": 3}],
+                          "path": ["connector"]
+                        }
+                      ],
+                      "data": {
+                        "resourceAccessRemove": null
+                      }
+                    }
+                """
+
+        mocked_responses.post(
+            test_url,
+            status=200,
+            body=failed_response,
+            match=[
+                responses.matchers.json_params_matcher(
+                    {"variables": expected_variables}, strict_match=False
+                )
+            ],
+        )
+
+        result = api_client.resource_access_remove(
+            resource_id=resource_id, principal_id=principal_id
+        )
+        assert result is False
+
+    def test_resource_access_remove_already_deleted_returns_true(
         self, test_url, api_client, mocked_responses
     ):
         resource_id = "test-resource"
@@ -101,7 +140,49 @@ class TestResourceAccessAPIs:
         mocked_responses.post(
             test_url,
             status=200,
-            body=json.dumps({"data": {"resourceAccessRemove": {"ok": False}}}),
+            body=json.dumps(
+                {
+                    "data": {
+                        "resourceAccessRemove": {
+                            "ok": False,
+                            "error": f"Resource with id '{resource_id}' does not exist",
+                        }
+                    }
+                }
+            ),
+            match=[
+                responses.matchers.json_params_matcher(
+                    {"variables": expected_variables}, strict_match=False
+                )
+            ],
+        )
+
+        result = api_client.resource_access_remove(
+            resource_id=resource_id, principal_id=principal_id
+        )
+        assert result is True
+
+    def test_resource_access_remove_raises_if_unknown_error(
+        self, test_url, api_client, mocked_responses
+    ):
+        resource_id = "test-resource"
+        principal_id = "test-principal"
+
+        expected_variables = {"resourceId": resource_id, "principalId": principal_id}
+
+        mocked_responses.post(
+            test_url,
+            status=200,
+            body=json.dumps(
+                {
+                    "data": {
+                        "resourceAccessRemove": {
+                            "ok": False,
+                            "error": "Something unknown happened...",
+                        }
+                    }
+                }
+            ),
             match=[
                 responses.matchers.json_params_matcher(
                     {"variables": expected_variables}, strict_match=False

--- a/app/api/tests/test_client_resource_access.py
+++ b/app/api/tests/test_client_resource_access.py
@@ -99,19 +99,19 @@ class TestResourceAccessAPIs:
         expected_variables = {"resourceId": resource_id, "principalId": principal_id}
 
         failed_response = """
-                    {
-                      "errors": [
-                        {
-                          "message": "{'id': ['Unable to parse global ID']}",
-                          "locations": [{"line": 2, "column": 3}],
-                          "path": ["connector"]
-                        }
-                      ],
-                      "data": {
-                        "resourceAccessRemove": null
-                      }
-                    }
-                """
+            {
+              "errors": [
+                {
+                  "message": "{'id': ['Unable to parse global ID']}",
+                  "locations": [{"line": 2, "column": 3}],
+                  "path": ["connector"]
+                }
+              ],
+              "data": {
+                "resourceAccessRemove": null
+              }
+            }
+        """
 
         mocked_responses.post(
             test_url,


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #403 

## Changes

- Handle exception in `resource_access_remove` API call
