### PR TITLE
Fix  clusterrole with permissions over twingategroups objects

### DIFF
--- a/deploy/twingate-operator/templates/clusterrole.yaml
+++ b/deploy/twingate-operator/templates/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
 
   # Application
   - apiGroups: [twingate.com]
-    resources: [twingateresources, twingateresourceaccesses, twingateconnectors]
+    resources: [twingateresources, twingateresourceaccesses, twingateconnectors, twingategroups]
     verbs: [list, watch, patch, get, create]
 
   - apiGroups: ["*"]


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: TwingateGroup objects cannot be handled by the operator due to missing permissions over the TwingateGroup apis

## Changes

- Fix operator permissions over twingategroups apis

## Steps to reproduce:
- apply a twingate group object kind
- operator logs an error about missing permissions to list twingategroups
- the group is not created on twingate side