### PR TITLE
chore: Enable Configuration of Kopf Watch Settings via Environment Variables

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -5,7 +5,7 @@ import tomllib
 from base64 import b64decode
 from typing import Annotated, ClassVar
 
-from kopf._cogs.configs.configuration import WatchingSettings
+import kopf
 from pydantic.functional_validators import AfterValidator
 from pydantic_core._pydantic_core import ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -39,16 +39,15 @@ class KopfWatchingSettings(BaseSettings):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def get_kopf_settings(self):
-        settings = WatchingSettings()
+    def update_kopf_watching_settings(self, settings: kopf.OperatorSettings):
         if self.server_timeout:
-            settings.server_timeout = self.server_timeout
+            settings.watching.server_timeout = self.server_timeout
         if self.client_timeout:
-            settings.client_timeout = self.client_timeout
+            settings.watching.client_timeout = self.client_timeout
         if self.connect_timeout:
-            settings.connect_timeout = self.connect_timeout
+            settings.watching.connect_timeout = self.connect_timeout
         if self.reconnect_backoff:
-            settings.reconnect_backoff = self.reconnect_backoff
+            settings.watching.reconnect_backoff = self.reconnect_backoff
         return settings
 
 class TwingateOperatorSettings(BaseSettings):

--- a/app/settings.py
+++ b/app/settings.py
@@ -5,6 +5,7 @@ import tomllib
 from base64 import b64decode
 from typing import Annotated, ClassVar
 
+from kopf._cogs.configs.configuration import WatchingSettings
 from pydantic.functional_validators import AfterValidator
 from pydantic_core._pydantic_core import ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -26,6 +27,29 @@ def validate_graphql_global_id(value: str) -> str:
 
 GlobalID = Annotated[str, AfterValidator(validate_graphql_global_id)]
 
+
+class KopfWatchingSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="KOPF_WATCHING_")
+
+    server_timeout: float | None = None
+    client_timeout: float | None = None
+    connect_timeout: float | None = None
+    reconnect_backoff: float | None = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get_kopf_settings(self):
+        settings = WatchingSettings()
+        if self.server_timeout:
+            settings.server_timeout = self.server_timeout
+        if self.client_timeout:
+            settings.client_timeout = self.client_timeout
+        if self.connect_timeout:
+            settings.connect_timeout = self.connect_timeout
+        if self.reconnect_backoff:
+            settings.reconnect_backoff = self.reconnect_backoff
+        return settings
 
 class TwingateOperatorSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="TWINGATE_")

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import kopf
 from pydantic import ValidationError
 
 from app.handlers import *  # noqa: F403
-from app.settings import TwingateOperatorSettings
+from app.settings import TwingateOperatorSettings, KopfWatchingSettings
 
 
 class TwingateSmartProgressStorage(kopf.SmartProgressStorage):
@@ -32,6 +32,7 @@ def startup(
 ):
     logger.info("Operator is starting up...")
 
+    settings.watching = KopfWatchingSettings().get_kopf_settings()
     settings.persistence.finalizer = "twingate.com/finalizer"
     settings.persistence.diffbase_storage = TwingateAnnotationsDiffBaseStorage()
     settings.persistence.progress_storage = TwingateSmartProgressStorage()

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def startup(
 ):
     logger.info("Operator is starting up...")
 
-    settings.watching = KopfWatchingSettings().get_kopf_settings()
+    KopfWatchingSettings().update_kopf_watching_settings(settings)
     settings.persistence.finalizer = "twingate.com/finalizer"
     settings.persistence.diffbase_storage = TwingateAnnotationsDiffBaseStorage()
     settings.persistence.progress_storage = TwingateSmartProgressStorage()


### PR DESCRIPTION
## Related Tickets & Documents

We have observed that our operator stops listening to resource changes after running for some time.

After investigating the issue, we found several related Kopf issues that describe this behavior:
- https://github.com/nolar/kopf/issues/957
- https://github.com/nolar/kopf/issues/585

One solution would be to set the following:
```
settings.watching.client_timeout = 60
settings.watching.server_timeout = 60
```
However, passing these configurations to Kopf is currently not supported in the operator.

## Changes

Enabled configuration of Kopf’s watching settings through environment variables.
