### PR TITLE
fix: Enable Extra Env in Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ and manage Twingate resources within a Kubernetes environment. It provides
 seamless integration between your Kubernetes clusters and the Twingate Zero
 Trust Network.
 
-[Wiki](https://github.com/Twingate/kubernetes-operator/wiki)  |  [Getting Started](https://github.com/Twingate/kubernetes-operator/wiki/Getting-Started)  |  [API Reference](https://github.com/Twingate/kubernetes-operator/wiki/API-Reference)
+[Wiki][1]  |  [Getting Started][2]  |  [API Reference][3]
 
+[1]: https://github.com/Twingate/kubernetes-operator/wiki
+[2]: https://github.com/Twingate/kubernetes-operator/wiki/Getting-Started
+[3]: https://github.com/Twingate/kubernetes-operator/wiki/API-Reference
 
 ## Prerequisites
 

--- a/deploy/twingate-operator/Chart.yaml
+++ b/deploy/twingate-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: twingate-operator
 description: A Helm chart for installing twingate-operator
 type: application
-version: 0.1.10
+version: 0.1.11

--- a/deploy/twingate-operator/templates/deployment.yaml
+++ b/deploy/twingate-operator/templates/deployment.yaml
@@ -70,11 +70,9 @@ spec:
           - name: TWINGATE_REMOTE_NETWORK_NAME
             value: {{ .Values.twingateOperator.remoteNetworkName }}
           {{- end }}
-          {{- if .Values.extraEnvVars }}
-          {{- range .Values.extraEnvVars }}
-          - name: {{ .name }}
-            value: {{ .value | quote }}
-          {{- end }}
+          {{- range $key, $value := .Values.extraEnvVars }}
+          - name: {{ $key }}
+            value:  {{ $value | quote }}
           {{- end }}
         livenessProbe:
           httpGet:

--- a/deploy/twingate-operator/templates/deployment.yaml
+++ b/deploy/twingate-operator/templates/deployment.yaml
@@ -70,6 +70,12 @@ spec:
           - name: TWINGATE_REMOTE_NETWORK_NAME
             value: {{ .Values.twingateOperator.remoteNetworkName }}
           {{- end }}
+          {{- if .Values.extraEnvVars }}
+          {{- range .Values.extraEnvVars }}
+          - name: {{ .name }}
+            value: {{ .value | quote }}
+          {{- end }}
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -74,10 +74,10 @@ affinity: {}
 
 priorityClassName: ""
 
-## @param extraEnvVars Array of additional environment variables to inject into the operator.
-## e.g:
+## @param extraEnvVars Dictionary of additional environment variables to inject into the operator.
+## Example:
 ## extraEnvVars:
-##   - name: FOO
-##     value: "bar"
+##   FOO: bar
+##   HELLO: world
 ##
-extraEnvVars: []
+extraEnvVars: {}

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -73,3 +73,11 @@ tolerations: []
 affinity: {}
 
 priorityClassName: ""
+
+## @param extraEnvVars Array with extra environment variables
+## e.g:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
+##
+extraEnvVars: []

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -74,7 +74,7 @@ affinity: {}
 
 priorityClassName: ""
 
-## @param extraEnvVars Array with extra environment variables
+## @param extraEnvVars Array of additional environment variables to inject into the operator.
 ## e.g:
 ## extraEnvVars:
 ##   - name: FOO


### PR DESCRIPTION
## Related Tickets & Documents

In [PR #487](https://github.com/Twingate/kubernetes-operator/pull/487), support was added to provide additional environment variables to the operator.

However, it is currently not possible to specify these variables via the Helm Chart.

## Changes

This PR enables the ability to provide extra environment variables to the operator from the Helm Chart.