### PR TITLE
fix: Allow extra env vars in the operator's Chart

### DIFF
--- a/deploy/test/golden/extraEnvVars.golden.yaml
+++ b/deploy/test/golden/extraEnvVars.golden.yaml
@@ -1,0 +1,145 @@
+---
+# Source: twingate-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-twingate-operator
+  namespace: default
+  labels:
+    helm.sh/chart: twingate-operator-major.minor.patch-test
+    app.kubernetes.io/name: twingate-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: twingate-operator/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-twingate-operator
+  namespace: default
+  labels:
+    helm.sh/chart: twingate-operator-major.minor.patch-test
+    app.kubernetes.io/name: twingate-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/managed-by: Helm
+data:
+  TWINGATE_API_KEY: PGFwaSBrZXk+
+---
+# Source: twingate-operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-twingate-operator-role-cluster
+rules:
+  # Framework: runtime observation of namespaces & CRDs (addition/deletion).
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [list, watch]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [list, watch]
+  - apiGroups: ["", "events.k8s.io"]
+    resources: [events]
+    verbs: ['*']
+
+  # Framework: admission webhook configuration management.
+  - apiGroups: [admissionregistration.k8s.io/v1, admissionregistration.k8s.io/v1beta1]
+    resources: [validatingwebhookconfigurations, mutatingwebhookconfigurations]
+    verbs: [create, patch]
+
+  # Application
+  - apiGroups: [twingate.com]
+    resources: [twingateresources, twingateresourceaccesses, twingateconnectors, twingategroups]
+    verbs: [list, watch, patch, get, create]
+
+  - apiGroups: ["*"]
+    resources: [pods, services, secrets, services/status]
+    verbs: [list, watch, patch, get, create, delete]
+---
+# Source: twingate-operator/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-twingate-operator-rolebinding-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-twingate-operator-role-cluster
+subjects:
+  - kind: ServiceAccount
+    name: test-twingate-operator
+    namespace: default
+---
+# Source: twingate-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-twingate-operator
+  namespace: default
+  labels:
+    helm.sh/chart: twingate-operator-major.minor.patch-test
+    app.kubernetes.io/name: twingate-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: twingate-operator
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: twingate-operator
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-twingate-operator
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: twingate-operator
+        securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+        image: "twingate/kubernetes-operator:latest"
+        imagePullPolicy: IfNotPresent
+        command:
+          - kopf
+          - run
+          - ./main.py
+          - "-A"
+          - "--standalone"
+          - "--liveness=http://0.0.0.0:8080/healthz"
+          - "--log-format=full"
+        env:
+          - name: TWINGATE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-twingate-operator
+                key: TWINGATE_API_KEY
+          - name: TWINGATE_NETWORK
+            value: <network slug>
+          - name: TWINGATE_HOST
+            value: twingate.com
+          - name: TWINGATE_REMOTE_NETWORK_ID
+            value: <remote network id>
+          - name: FOO
+            value: "BAR"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+        resources:
+            {}

--- a/deploy/test/golden/extraEnvVars.yaml
+++ b/deploy/test/golden/extraEnvVars.yaml
@@ -1,0 +1,9 @@
+twingateOperator:
+  apiKey: "<api key>"
+  network: "<network slug>"
+  remoteNetworkId: "<remote network id>"
+
+
+extraEnvVars:
+  - name: FOO
+    value: BAR

--- a/deploy/twingate-operator/Chart.yaml
+++ b/deploy/twingate-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: twingate-operator
 description: A Helm chart for installing twingate-operator
 type: application
-version: 0.1.10
+version: 0.1.11

--- a/deploy/twingate-operator/templates/deployment.yaml
+++ b/deploy/twingate-operator/templates/deployment.yaml
@@ -70,7 +70,12 @@ spec:
           - name: TWINGATE_REMOTE_NETWORK_NAME
             value: {{ .Values.twingateOperator.remoteNetworkName }}
           {{- end }}
-          {{- toYaml .Values.extraEnvVars | nindent 8 }}
+          {{- with .Values.extraEnvVars }}
+          {{- range . }}
+          - name: {{ .name }}
+            value: {{ .value | quote }}
+          {{- end }}
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/twingate-operator/templates/deployment.yaml
+++ b/deploy/twingate-operator/templates/deployment.yaml
@@ -70,6 +70,7 @@ spec:
           - name: TWINGATE_REMOTE_NETWORK_NAME
             value: {{ .Values.twingateOperator.remoteNetworkName }}
           {{- end }}
+          {{- toYaml .Values.extraEnvVars | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/twingate-operator/values.schema.json
+++ b/deploy/twingate-operator/values.schema.json
@@ -43,6 +43,12 @@
                 "pullPolicy": "Always"
             }]
         },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to the operator container",
+            "default": [],
+            "items": {}
+        },
         "twingateOperator": {
             "type": "object",
             "default": {},

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -74,10 +74,10 @@ affinity: {}
 
 priorityClassName: ""
 
-## Array with extra environment variables to add to the operator container
-## e.g:
-## extraEnvVars:
-##   - name: FOO
-##     value: "bar"
-##
+# Array with extra environment variables to add to the operator container
+# e.g:
+# extraEnvVars:
+#   - name: FOO
+#     value: "bar"
+#
 extraEnvVars: []

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -73,3 +73,11 @@ tolerations: []
 affinity: {}
 
 priorityClassName: ""
+
+## Array with extra environment variables to add to the operator container
+## e.g:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
+##
+extraEnvVars: []


### PR DESCRIPTION
## Related Tickets & Documents

Fixes https://github.com/Twingate/kubernetes-operator/pull/487

## Changes

We've added the feature to allow configuring KOPF using env vars but we also need the chart to support defining custom env vars
