### PR TITLE
feat: Helm chart - Add `existingRemoteNetworkIdSecret`

### DIFF
--- a/deploy/test/golden/error-too-many-remotenetwork-definitions.golden.yaml
+++ b/deploy/test/golden/error-too-many-remotenetwork-definitions.golden.yaml
@@ -1,6 +1,5 @@
 error while running command: exit status 1; Error: values don't meet the specifications of the schema(s) in the following chart(s):
 twingate-operator:
 - twingateOperator: Must validate one and only one schema (oneOf)
-- twingateOperator: remoteNetworkId is required
 - twingateOperator: Must validate all the schemas (allOf)
 

--- a/deploy/test/golden/error-too-many-remotenetwork-definitions.yaml
+++ b/deploy/test/golden/error-too-many-remotenetwork-definitions.yaml
@@ -1,0 +1,7 @@
+twingateOperator:
+  apiKey: "<api key>"
+  network: "<network slug>"
+  remoteNetworkId: "<remote network id>"
+  existingRemoteNetworkIdSecret:
+    name: my-secret
+    key: MY_TWINGATE_REMOTE_NETWORK_ID

--- a/deploy/test/golden/existingRemoteNetworkIdSecret.golden.yaml
+++ b/deploy/test/golden/existingRemoteNetworkIdSecret.golden.yaml
@@ -1,0 +1,132 @@
+---
+# Source: twingate-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-twingate-operator
+  namespace: default
+  labels:
+    helm.sh/chart: twingate-operator-major.minor.patch-test
+    app.kubernetes.io/name: twingate-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: twingate-operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-twingate-operator-role-cluster
+rules:
+  # Framework: runtime observation of namespaces & CRDs (addition/deletion).
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [list, watch]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [list, watch]
+  - apiGroups: ["", "events.k8s.io"]
+    resources: [events]
+    verbs: ['*']
+
+  # Framework: admission webhook configuration management.
+  - apiGroups: [admissionregistration.k8s.io/v1, admissionregistration.k8s.io/v1beta1]
+    resources: [validatingwebhookconfigurations, mutatingwebhookconfigurations]
+    verbs: [create, patch]
+
+  # Application
+  - apiGroups: [twingate.com]
+    resources: [twingateresources, twingateresourceaccesses, twingateconnectors, twingategroups]
+    verbs: [list, watch, patch, get, create]
+
+  - apiGroups: ["*"]
+    resources: [pods, services, secrets, services/status]
+    verbs: [list, watch, patch, get, create, delete]
+---
+# Source: twingate-operator/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-twingate-operator-rolebinding-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-twingate-operator-role-cluster
+subjects:
+  - kind: ServiceAccount
+    name: test-twingate-operator
+    namespace: default
+---
+# Source: twingate-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-twingate-operator
+  namespace: default
+  labels:
+    helm.sh/chart: twingate-operator-major.minor.patch-test
+    app.kubernetes.io/name: twingate-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: twingate-operator
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: twingate-operator
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-twingate-operator
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: twingate-operator
+        securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+        image: "twingate/kubernetes-operator:latest"
+        imagePullPolicy: IfNotPresent
+        command:
+          - kopf
+          - run
+          - ./main.py
+          - "-A"
+          - "--standalone"
+          - "--liveness=http://0.0.0.0:8080/healthz"
+          - "--log-format=full"
+        env:
+          - name: TWINGATE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: MY_TWINGATE_API_KEY
+          - name: TWINGATE_NETWORK
+            value: <network slug>
+          - name: TWINGATE_HOST
+            value: twingate.com
+          - name: TWINGATE_REMOTE_NETWORK_ID
+            valueFrom:
+              secretKeyRef:
+                name: my-other-secret
+                key: MY_TWINGATE_REMOTE_NETWORK_ID
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+        resources:
+            {}

--- a/deploy/test/golden/existingRemoteNetworkIdSecret.yaml
+++ b/deploy/test/golden/existingRemoteNetworkIdSecret.yaml
@@ -1,0 +1,8 @@
+twingateOperator:
+  existingAPIKeySecret:
+    name: my-secret
+    key: MY_TWINGATE_API_KEY
+  network: "<network slug>"
+  existingRemoteNetworkIdSecret:
+    name: my-other-secret
+    key: MY_TWINGATE_REMOTE_NETWORK_ID

--- a/deploy/twingate-operator/Chart.yaml
+++ b/deploy/twingate-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: twingate-operator
 description: A Helm chart for installing twingate-operator
 type: application
-version: 0.1.12  # This version value no longer used - its overriden when publishing the OCI in `release.yaml` CI workflow
+version: 0.1.13  # This version value no longer used - its overriden when publishing the OCI in `release.yaml` CI workflow
 home: https://twingate.com
 sources:
   - https://github.com/Twingate/kubernetes-operator

--- a/deploy/twingate-operator/templates/deployment.yaml
+++ b/deploy/twingate-operator/templates/deployment.yaml
@@ -62,6 +62,13 @@ spec:
             value: {{ required "Network name required" .Values.twingateOperator.network }}
           - name: TWINGATE_HOST
             value: {{ .Values.twingateOperator.host | default "twingate.com" }}
+          {{- if .Values.twingateOperator.existingRemoteNetworkIdSecret }}
+          - name: TWINGATE_REMOTE_NETWORK_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.twingateOperator.existingRemoteNetworkIdSecret.name }}
+                key: {{ .Values.twingateOperator.existingRemoteNetworkIdSecret.key }}
+          {{- end }}
           {{- if .Values.twingateOperator.remoteNetworkId }}
           - name: TWINGATE_REMOTE_NETWORK_ID
             value: {{ .Values.twingateOperator.remoteNetworkId }}

--- a/deploy/twingate-operator/values.schema.json
+++ b/deploy/twingate-operator/values.schema.json
@@ -74,6 +74,9 @@
                         },
                         {
                             "required": ["remoteNetworkName"]
+                        },
+                        {
+                            "required": ["existingRemoteNetworkIdSecret"]
                         }
                     ]
                 }
@@ -87,7 +90,6 @@
                     "properties": {
                         "name": {
                             "type": "string",
-                            "default": "",
                             "title": "The name of the Secret object",
                             "examples": [
                                 "twingate-operator"
@@ -95,7 +97,6 @@
                         },
                         "key": {
                             "type": "string",
-                            "default": "",
                             "title": "The key for the API Key value in the Secret object",
                             "examples": [
                                 "TWINGATE_API_KEY"
@@ -107,7 +108,28 @@
                         "key": "apiKey"
                     }]
                 },
-                "network": { "type": "string" },
+                "existingRemoteNetworkIdSecret": {
+                    "type": "object",
+                    "title": "An existing secret containing the reote network ID.",
+                    "required": ["name", "key"],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "The name of the Secret object",
+                            "examples": [
+                                "twingate-operator"
+                            ]
+                        },
+                        "key": {
+                            "type": "string",
+                            "title": "The key for the remote network ID value in the Secret object",
+                            "examples": [
+                                "REMOTE_NETWORK_ID"
+                            ]
+                        }
+                    }
+                },
+                    "network": { "type": "string" },
                 "remoteNetworkId": { "type": "string" },
                 "logFormat": {
                     "type": "string",

--- a/deploy/twingate-operator/values.schema.json
+++ b/deploy/twingate-operator/values.schema.json
@@ -129,7 +129,7 @@
                         }
                     }
                 },
-                    "network": { "type": "string" },
+                "network": { "type": "string" },
                 "remoteNetworkId": { "type": "string" },
                 "logFormat": {
                     "type": "string",

--- a/deploy/twingate-operator/values.schema.json
+++ b/deploy/twingate-operator/values.schema.json
@@ -68,7 +68,7 @@
                     ]
                 },
                 {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "required": ["remoteNetworkId"]
                         },

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -12,6 +12,9 @@ twingateOperator: {}
 #    key: TWINGATE_API_KEY
 #  network: "<network slug>"
 #  remoteNetworkId: "<remote network id>"
+#  existingRemoteNetworkIdSecret:
+#    name: my-secret
+#    key: TWINGATE_REMOTE_NETWORK_ID
 #  remoteNetworkName: "<remote network name>"
 #  logFormat: "plain|full|json"
 #  logVerbosity: "quiet|verbose|debug"

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -4,7 +4,7 @@
 
 # Required: you have to specify `network` and
 #  - either `apiKey` or `existingAPIKeySecret`
-#  - either `remoteNetworkId` or `remoteNetworkName`
+#  - either `remoteNetworkId`, `remoteNetworkName` or `existingRemoteNetworkIdSecret`
 twingateOperator: {}
 #  apiKey: "<api key>"
 #  existingAPIKeySecret:


### PR DESCRIPTION
Allow fetching remote network idea from an existing Secret object.

## Related Tickets & Documents

- Issue: #122 

## Changes

Add `existingRemoteNetworkIdSecret` configuration option to fetch the remote network ID from an existing `Secret` object.
