### PR TITLE
chore: Remove autoflake and use Ruff instead + Extra Ruff rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,13 +51,6 @@ repos:
         types: [python]
         args: [--py311-plus]
 
-      - id: autoflake
-        name: autoflake
-        entry: poetry run autoflake
-        language: system
-        types: [python]
-        require_serial: true
-
       - id: ruff
         name: ruff
         entry: poetry run ruff check

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import kopf
 import kubernetes
 import pytest
-import yaml  # type: ignore
+import yaml
 
 from app.handlers.handlers_services import (
     ALLOWED_EXTRA_ANNOTATIONS,

--- a/poetry.lock
+++ b/poetry.lock
@@ -186,20 +186,6 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
-name = "autoflake"
-version = "2.3.1"
-description = "Removes unused imports and unused variables"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "autoflake-2.3.1-py3-none-any.whl", hash = "sha256:3ae7495db9084b7b32818b4140e6dc4fc280b712fb414f5b8fe57b0a8e85a840"},
-    {file = "autoflake-2.3.1.tar.gz", hash = "sha256:c98b75dc5b0a86459c4f01a1d32ac7eb4338ec4317a4469515ff1e687ecd909e"},
-]
-
-[package.dependencies]
-pyflakes = ">=3.0.0"
-
-[[package]]
 name = "backoff"
 version = "2.2.1"
 description = "Function decoration for backoff and retry"
@@ -1915,17 +1901,6 @@ toml = ["tomli (>=2.0.1)"]
 yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
-name = "pyflakes"
-version = "3.1.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
-    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
-]
-
-[[package]]
 name = "pygments"
 version = "2.16.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2704,4 +2679,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b7e81c994a39180b590211a2e31445f1e1794aa532859ee1269ce53c4f5ecf5d"
+content-hash = "a5c45e3c4c08bdb2beadc0183f81044202c705c4fa484f638ad751f8f8cffcbf"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2492,6 +2492,17 @@ files = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20241230"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6"},
+    {file = "types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c"},
+]
+
+[[package]]
 name = "types-requests"
 version = "2.32.0.20241016"
 description = "Typing stubs for requests"
@@ -2679,4 +2690,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "a5c45e3c4c08bdb2beadc0183f81044202c705c4fa484f638ad751f8f8cffcbf"
+content-hash = "5a7fbf2f22cd6888eca4ad8c3f7ccda46c1dbbd2285e0966eae32da556e23de9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ tenacity = "^9.0.0"
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-autoflake = "^2.3.1"
 bandit = "^1.8.2"
 coveralls = "^3.3.1"
 factory-boy = "^3.3.1"
@@ -53,13 +52,6 @@ python-semantic-release = "^9.16.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.autoflake]
-in-place = true
-remove-all-unused-imports = true
-ignore-init-module-imports = true
-remove-duplicate-keys = true
-remove-unused-variables = true
 
 [tool.bandit]
 targets = ["app"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ select = [
     "I", # isort
     "F", # Pyflakes
     "E", "W", # pycodestyle
+    "ASYNC", # flake8-async
     "S", # flake8-bandit
     "Q", # flake8-quotes
     "G", # flake8-logging-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ ruff = "^0.9.1"
 syrupy = "^4.8.1"
 types-croniter = "^5.0.1.20241205"
 types-requests = "^2.32.0.20241016"
+types-pyyaml = "^6.0.12.20241230"
 [tool.poetry.group.build]
 optional = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,8 @@ select = [
     "TID", # flake8-tidy-imports
     "ERA", # eradicate
     "FLY", # flynt
+    "FURB", # refurb
+    "PGH", # pygrep-hooks
     "RUF", # Ruff-specific rules
 ]
 


### PR DESCRIPTION
## Related Tickets & Documents

- Issue:

## Changes

- Removed autoflake. We're already using Ruff for that functionality...
- Added FURB, PGH, ASYNC
- Added proper typechecking to `yaml` module
