### PR TITLE
docs: Fix typo 'closing' → 'cloning' in Helm installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Follow these steps to install the operator:
 helm upgrade twop oci://ghcr.io/twingate/helmcharts/twingate-operator --install --wait -f ./values.yaml
 ```
 
-### Helm by closing the git repository
+### Helm by cloning the git repository
 
 1. Clone this repository to your local machine.
 1. Use the `helm` chart in `./deploy/twingate-operator`:


### PR DESCRIPTION
**Changes**
This PR fixes a small typo in the README.md file:

- "Helm by **closing** the git repository" → "Helm by **cloning** the git repository"
- Ensures clarity in the installation instructions for users installing via Helm.

**Notes**
N/A (No breaking changes or alternative approaches considered.)