### PR TITLE
feat(crds): add categories to CRDs and fix indentation for shortNames to enhance organization and readability in Kubernetes resources

### DIFF
--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -129,4 +129,7 @@ spec:
     singular: twingateconnector
     kind: TwingateConnector
     shortNames:
-    - tc
+      - tc
+    categories:
+      - all
+      - twingate

--- a/deploy/twingate-operator/crds/twingate.com.twingategroup.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingategroup.yaml
@@ -45,4 +45,7 @@ spec:
     singular: twingategroup
     kind: TwingateGroup
     shortNames:
-    - tgg
+      - tgg
+    categories:
+      - all
+      - twingate

--- a/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
@@ -86,6 +86,10 @@ spec:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
   scope: Namespaced
   names:
     plural: twingateresourceaccesses
@@ -94,3 +98,6 @@ spec:
     shortNames:
       - tgra
       - tacc
+    categories:
+      - all
+      - twingate

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -146,5 +146,8 @@ spec:
     singular: twingateresource
     kind: TwingateResource
     shortNames:
-    - tgr
-    - tres
+      - tgr
+      - tres
+    categories:
+      - all
+      - twingate


### PR DESCRIPTION
## Changes

Added category to our objects so that they appear when doing `kubectl get all` but also added a specific twingate category so all our objects appear on `kubectl get twingate`

Example:
```
➜ kubectl get twingate
NAME                                                              ID                         DISPLAY NAME             AGE
twingateconnector.twingate.com/my-connector-auto-updating-image   Q29ubmVjdG9yOjk3MDU1OQ==   nondescript-jackrabbit   18m
twingateconnector.twingate.com/my-connector-fixed-image           Q29ubmVjdG9yOjk3MDU2MA==   icy-orca                 18m

NAME                                 ID                     DISPLAY NAME    AGE
twingategroup.twingate.com/example   R3JvdXA6MzA1NDM5NA==   Example Group   18m

NAME                                                     CREATE STATUS   SYNC STATUS   AGE
twingateresourceaccess.twingate.com/my-twingate-access                                 2m51s

NAME                                                 ID                         DISPLAY NAME                    ADDRESS                                ALIAS            AGE
twingateresource.twingate.com/my-service-resource    UmVzb3VyY2U6MzA3ODgwNQ==   my-service-resource             my-service.default.svc.cluster.local   myapp.internal   9d
twingateresource.twingate.com/my-twingate-resource   UmVzb3VyY2U6MzA3ODgwNA==   My K8S Resource demo updated!   my.default.cluster.local               mine.local       9d
```
