### PR TITLE
docs: Improve `DEVELOPER.md` and `README.md` documentations

### DIFF
--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -1,4 +1,5 @@
 TWINGATE_API_KEY=<Twingate API Key>
-TWINGATE_NETWORK=<Twingate network name. ex: my-network if at https://my-network.twingate.com>
+TWINGATE_NETWORK=<Twingate network slug - <slug>.twingate.com>
 TWINGATE_HOST=<for debugging purposes. twingate.com by default>
 TWINGATE_REMOTE_NETWORK_ID=<Global ID for the remote network this operator is running at>
+TWINGATE_TEST_PRINCIPAL_ID=<Global ID of the principal (Group or Service Account) used to run tests locally>

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -1,5 +1,5 @@
 TWINGATE_API_KEY=<Twingate API Key>
-TWINGATE_NETWORK=<Twingate network slug - <slug>.twingate.com>
+TWINGATE_NETWORK=<Twingate network ID. For example, network ID is autoco if your URL is autoco.twingate.com>
 TWINGATE_HOST=<for debugging purposes. twingate.com by default>
 TWINGATE_REMOTE_NETWORK_ID=<Global ID for the remote network this operator is running at>
-TWINGATE_TEST_PRINCIPAL_ID=<Global ID of the principal (Group or Service Account) used to run tests locally>
+TWINGATE_TEST_PRINCIPAL_ID=<Global ID of the principal (Group or Service Account) used to run integration tests locally>

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -3,15 +3,15 @@
 ## Local Installation
 
 1. Clone this repository to your local machine.
-2. Use the `helm` chart in `./deploy/twingate-operator`:
+1. Use the `helm` chart in `./deploy/twingate-operator`:
    1. Create a custom `values.yaml`:
 
        ```bash
        cp ./deploy/twingate-operator/values.yaml ./deploy/twingate-operator/values.local.yaml
        ```
 
-   2. Edit the settings (`twingateOperator` specifically) in `./deploy/twingate-operator/values.local.yaml`
-   3. Deploy:
+   1. Edit the settings (`twingateOperator` specifically) in `./deploy/twingate-operator/values.local.yaml`
+   1. Deploy:
 
       ```bash
       helm upgrade twop ./deploy/twingate-operator --install --wait -f ./deploy/twingate-operator/values.local.yaml
@@ -22,25 +22,25 @@
 1. We use [asdf](https://asdf-vm.com/) for version management. Install it and
    then run `asdf install` in the root of this repo to install the correct
    versions of the tools we use.
-2. Copy the local env file and edit the values to match your environment:
+1. Copy the local env file and edit the values to match your environment:
 
     ```bash
     cp .envrc.local.example .envrc.local
     ```
 
-3. We use [direnv](https://direnv.net/) to manage environment variables. Install
+1. We use [direnv](https://direnv.net/) to manage environment variables. Install
    it and then run `direnv allow` in the root of this repo to allow it to manage
    your environment variables.
-4. We use [minikube](https://minikube.sigs.k8s.io/docs/start/) to run Kubernetes cluster locally.
+1. We use [minikube](https://minikube.sigs.k8s.io/docs/start/) to run Kubernetes cluster locally.
    Install it and then run `minikube start`.
-5. Apply the custom CRDs to the cluster:
+1. Apply the custom CRDs to the cluster:
 
    ```bash
    kubectl apply -f deploy/twingate-operator/crds/
    ```
 
-6. Run `make test-int` to see integration tests pass.
-7. You can now edit code and run `make run` to run the operator locally.
+1. Run `make test-int` to see integration tests pass.
+1. You can now edit code and run `make run` to run the operator locally.
    1. You'll also want to `poetry run pre-commit install` to make sure you have
       the pre-commit checks running locally.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -11,11 +11,11 @@
        ```
 
    2. Edit the settings (`twingateOperator` specifically) in `./deploy/twingate-operator/values.local.yaml`
-3. Deploy:
+   3. Deploy:
 
-   ```bash
-   helm upgrade twop ./deploy/twingate-operator --install --wait -f ./deploy/twingate-operator/values.local.yaml
-   ```
+      ```bash
+      helm upgrade twop ./deploy/twingate-operator --install --wait -f ./deploy/twingate-operator/values.local.yaml
+      ```
 
 ## Development
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -3,17 +3,15 @@
 ## Local Installation
 
 1. Clone this repository to your local machine.
-1. User the `helm` chart in `./deploy/twingate-operator`:
-
+2. Use the `helm` chart in `./deploy/twingate-operator`:
    1. Create a custom `values.yaml`:
 
-   ```bash
-   cp ./deploy/twingate-operator/values.yaml ./deploy/twingate-operator/values.local.yaml
-   ```
+       ```bash
+       cp ./deploy/twingate-operator/values.yaml ./deploy/twingate-operator/values.local.yaml
+       ```
 
-   1. Edit the settings (`twingateOperator` specifically) in
-      `./deploy/twingate-operator/values.local.yaml`
-   1. Deploy:
+   2. Edit the settings (`twingateOperator` specifically) in `./deploy/twingate-operator/values.local.yaml`
+3. Deploy:
 
    ```bash
    helm upgrade twop ./deploy/twingate-operator --install --wait -f ./deploy/twingate-operator/values.local.yaml
@@ -24,19 +22,26 @@
 1. We use [asdf](https://asdf-vm.com/) for version management. Install it and
    then run `asdf install` in the root of this repo to install the correct
    versions of the tools we use.
-1. We use [direnv](https://direnv.net/) to manage environment variables. Install
+2. Copy the local env file and edit the values to match your environment:
+
+    ```bash
+    cp .envrc.local.example .envrc.local
+    ```
+
+3. We use [direnv](https://direnv.net/) to manage environment variables. Install
    it and then run `direnv allow` in the root of this repo to allow it to manage
    your environment variables.
-1. `cp .envrc.local.example .envrc.local` and edit the values to match your
-   environment.
-1. Install [minikube](https://minikube.sigs.k8s.io/docs/start/)
-   1. `brew install minikube`
-1. `minikube start`
-1. Apply the custom CRDs to the cluster -
-   `kubectl apply -f deploy/twingate-operator/crds/`
-1. Run `make test-int` to see integration tests pass.
-1. You can now edit code and run `make run` to run the operator locally
-   1. You'll also want to `peotry run pre-commit install` to make sure you have
+4. We use [minikube](https://minikube.sigs.k8s.io/docs/start/) to run Kubernetes cluster locally.
+   Install it and then run `minikube start`.
+5. Apply the custom CRDs to the cluster:
+
+   ```bash
+   kubectl apply -f deploy/twingate-operator/crds/
+   ```
+
+6. Run `make test-int` to see integration tests pass.
+7. You can now edit code and run `make run` to run the operator locally.
+   1. You'll also want to `poetry run pre-commit install` to make sure you have
       the pre-commit checks running locally.
 
 ### PyCharm & IDEs
@@ -57,7 +62,7 @@ Congratulations! You are ready to develop and debug the Twingate operator.
 
 ### Dev Releases
 
-When a PR is merged to `main` the `CI` github workflow will run and publish a
+When a PR is merged to `main` the `CI` GitHub workflow will run and publish a
 new dev release to docker. This dev release version is determined by patching
 the current in `pyproject.toml` and adding a `-dev.<build number>` suffix.
 
@@ -75,8 +80,8 @@ tags:
   * Update version in `pyproject.toml`
   * Update `CHANGELOG.md`
   * Create a tag for the version and commit
-* Once pushed a Github workflow will
-  * Create a Github release
+* Once pushed a GitHub workflow will
+  * Create a GitHub release
   * Publish the following tags to dockerhub:
     * `latest`
     * `<major>`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Trust Network.
 - Twingate account setup with a `Remote Network` for the Kubernetes cluster and
  connectors deployed (see [this Helm chart](https://github.com/Twingate/helm-charts)
  if required)
-- `Read/Write` API token - this can be generated in the Twingate Admin Console
+- Twingate API token with `Read/Write/Provision` permissions - this can be generated in the Twingate Admin Console
 
 ## Installation
 


### PR DESCRIPTION
## Changes
- Update `.envrc.local.example` to include missing envvar `TWINGATE_TEST_PRINCIPAL_ID`, which is needed to run [`test_resource_flows`](https://github.com/Twingate/kubernetes-operator/blob/c6ec9e2d42fe03023a48d6e6cdc6cac041aeab7f/tests_integration/test_resource_flows.py#L213-L214) locally
- Update `README.md` instructions to include `Provision` permission for Twingate API token
- Update `DEVELOPER.md` 
  - Update local development instructions to be clearer
  - Fix some minor typos