### PR TITLE
chore: Remove redundant integration test marker

### DIFF
--- a/tests_integration/test_crds_connector.py
+++ b/tests_integration/test_crds_connector.py
@@ -11,7 +11,6 @@ def unique_connector_name(sequential_number, ci_run_number):
     return f"conn-{ci_run_number}-{sequential_number}"
 
 
-@pytest.mark.integration
 class TestConnectorCRD:
     def test_no_image_or_imagepolicy(self, unique_connector_name):
         result = kubectl_create(


### PR DESCRIPTION
## Changes
- Remove `integration` test marker on `TestConnectorCRD`
