### PR TITLE
fix: k8s Service annotations not removed properly

### DIFF
--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -283,7 +283,7 @@ class TwingateResourceAPIs:
                 "id": resource.id,
                 "name": resource.name,
                 "address": resource.address,
-                "alias": resource.alias,
+                "alias": "" if resource.alias is None else resource.alias,
                 "isVisible": resource.is_visible,
                 "isBrowserShortcutEnabled": resource.is_browser_shortcut_enabled,
                 "remoteNetworkId": resource.remote_network_id,

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -65,9 +65,7 @@ class TestServiceToTwingateResource:
         expected = {
             "apiVersion": "twingate.com/v1beta",
             "kind": "TwingateResource",
-            "metadata": {
-                "name": "my-service-resource",
-            },
+            "metadata": {"name": "my-service-resource", "labels": {"env": "dev"}},
             "spec": {
                 "name": "my-service-resource",
                 "address": "my-service.default.svc.cluster.local",

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -22,6 +22,8 @@ def example_service_body():
     kind: Service
     metadata:
       name: my-service
+      labels:
+        env: dev
       annotations:
         twingate.com/resource: "true"
         twingate.com/resource-alias: "myapp.internal"
@@ -151,10 +153,35 @@ class TestTwingateServiceCreate:
     def test_update_service_propogates_changes_to_twingate_resource(
         self, example_service_body, kopf_handler_runner, k8s_customobjects_client_mock
     ):
-        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = {
-            "metadata": {"name": "my-service-resource"},
-            "spec": {"address": "my-service.default.svc.cluster.local"},
+        existing_resource = {
+            "metadata": {"name": "my-service-resource", "labels": {}},
+            "spec": {
+                "id": "1",
+                "name": "my-service-resource",
+                "address": "my-service.default.svc.cluster.local",
+                "protocols": {
+                    "allowIcmp": False,
+                    "tcp": {
+                        "policy": "RESTRICTED",
+                        "ports": [{"start": 80, "end": 80}, {"start": 443, "end": 443}],
+                    },
+                    "udp": {
+                        "policy": "RESTRICTED",
+                        "ports": [{"start": 22, "end": 22}],
+                    },
+                },
+            },
         }
+        updated_resource = {
+            "metadata": {**existing_resource["metadata"], "labels": {"env": "dev"}},
+            "spec": {
+                **existing_resource["spec"],
+                "alias": "myapp.internal",
+            },
+        }
+        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = (
+            existing_resource
+        )
 
         twingate_service_create(
             example_service_body,
@@ -164,12 +191,12 @@ class TestTwingateServiceCreate:
             MagicMock(),
         )
 
-        k8s_customobjects_client_mock.patch_namespaced_custom_object.assert_called_once_with(
+        k8s_customobjects_client_mock.replace_namespaced_custom_object.assert_called_once_with(
             "twingate.com",
             "v1beta",
             "default",
             "twingateresources",
             "my-service-resource",
-            service_to_twingate_resource(example_service_body, "default"),
+            updated_resource,
         )
         k8s_customobjects_client_mock.create_namespaced_custom_object.assert_not_called()


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #607 

## Changes
- Update service handler to use k8s `replace_namespaced_custom_object` API instead of `patch_namespaced_custom_object`
- Update integration test to test scenario where we removing annotations and labels from k8s Service