### PR TITLE
feat: Support `livenessProbe`, `readinessProbe` and enhance security by setting `readOnlyRootFilesystem` on `TwingateConnector`

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -47,6 +47,8 @@ def get_connector_pod(
     container_extra = spec.container_extra
     extra_env = container_extra.pop("env", [])
     extra_env_from = container_extra.pop("envFrom", [])
+    extra_volumes = container_extra.pop("volumes", [])
+    extra_volume_mounts = container_extra.pop("volumeMounts", [])
 
     # fmt: off
     pod_spec = {
@@ -100,13 +102,14 @@ def get_connector_pod(
                     {
                         "name": "twingate-socket",
                         "mountPath": "/var/run/twingate",
-                    }
+                    },
+                    *extra_volume_mounts
                 ],
                 **container_extra,
             },
             *spec.sidecar_containers,
         ],
-        "volumes": [{"name": "twingate-socket", "emptyDir": {}}],
+        "volumes": [{"name": "twingate-socket", "emptyDir": {}}, *extra_volumes],
         **spec.pod_extra,
     }
     pod_annotations = spec.pod_annotations | {ANNOTATION_POD_SPEC_VERSION: ANNOTATION_POD_SPEC_VERSION_VALUE}

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -47,7 +47,9 @@ def get_connector_pod(
     container_extra = spec.container_extra
     extra_env = container_extra.pop("env", [])
     extra_env_from = container_extra.pop("envFrom", [])
-    extra_volumes = container_extra.pop("volumes", [])
+
+    pod_extra = spec.pod_extra
+    extra_volumes = pod_extra.pop("volumes", [])
     extra_volume_mounts = container_extra.pop("volumeMounts", [])
 
     # fmt: off

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -74,11 +74,39 @@ def get_connector_pod(
                     "seccompProfile": {
                         "type": "RuntimeDefault"
                     },
-               },
+                    "readOnlyRootFilesystem": True,
+                },
+                "readinessProbe": {
+                    "exec": {
+                        "command": [
+                            "/connectorctl",
+                            "health",
+                        ]
+                    },
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                },
+                "livenessProbe": {
+                    "exec": {
+                        "command": [
+                            "/connectorctl",
+                            "health",
+                        ]
+                    },
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                },
+                "volumeMounts": [
+                    {
+                        "name": "twingate-socket",
+                        "mountPath": "/var/run/twingate",
+                    }
+                ],
                 **container_extra,
             },
             *spec.sidecar_containers,
         ],
+        "volumes": [{"name": "twingate-socket", "emptyDir": {}}],
         **spec.pod_extra,
     }
     pod_annotations = spec.pod_annotations | {ANNOTATION_POD_SPEC_VERSION: ANNOTATION_POD_SPEC_VERSION_VALUE}

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -435,7 +435,7 @@ class TestGetConnectorPod:
     ):
         extra_volume = {"name": "extra-volume", "emptyDir": {}}
         _, crd = get_connector_and_crd(
-            spec_overrides={"container_extra": {"volumes": [extra_volume]}},
+            spec_overrides={"pod_extra": {"volumes": [extra_volume]}},
         )
 
         pod = get_connector_pod(crd, mock_tenant_url, mock_image)

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -6,12 +6,18 @@ import pendulum
 import pytest
 
 from app.api.client_connectors import ConnectorTokens
-from app.crds import ConnectorImagePolicy, ConnectorSpec, TwingateConnectorCRD
+from app.crds import (
+    ConnectorImagePolicy,
+    ConnectorSpec,
+    K8sMetadata,
+    TwingateConnectorCRD,
+)
 from app.handlers.handlers_connectors import (
     ANNOTATION_LAST_VERSION_CHECK,
     ANNOTATION_NEXT_VERSION_CHECK,
     ANNOTATION_POD_SPEC_VERSION,
     ANNOTATION_POD_SPEC_VERSION_VALUE,
+    get_connector_pod,
     k8s_read_namespaced_pod,
     twingate_connector_create,
     twingate_connector_delete,
@@ -49,7 +55,7 @@ def get_connector_and_crd(connector_factory):
         crd = TwingateConnectorCRD(
             api_version="twingate.com/v1beta",
             kind="TwingateConnector",
-            metadata=dict(
+            metadata=K8sMetadata(
                 uid="123",
                 name=connector_spec.name,
                 namespace="default",
@@ -395,3 +401,46 @@ class TestTwingateConnectorPodReconciler_ImagePolicy:
         assert run.patch_mock.meta == {}
         run.k8s_client_mock.patch_namespaced_pod.assert_not_called()
         mock_get_image.assert_not_called()
+
+
+class TestGetConnectorPod:
+    @pytest.fixture
+    def mock_tenant_url(self):
+        return "https://test.twingate.com"
+
+    @pytest.fixture
+    def mock_image(self):
+        return "twingate/connector:latest"
+
+    def test_get_connector_with_extra_volume_mounts(
+        self, get_connector_and_crd, mock_tenant_url, mock_image
+    ):
+        extra_volume_mount = {
+            "name": "extra-volume-mount",
+            "mountPath": "/var/run/extra-volume",
+        }
+        _, crd = get_connector_and_crd(
+            spec_overrides={"container_extra": {"volumeMounts": [extra_volume_mount]}},
+        )
+
+        pod = get_connector_pod(crd, mock_tenant_url, mock_image)
+
+        assert pod.spec["containers"][0]["volumeMounts"] == [
+            {"name": "twingate-socket", "mountPath": "/var/run/twingate"},
+            extra_volume_mount,
+        ]
+
+    def test_get_connector_with_extra_volumes(
+        self, get_connector_and_crd, mock_tenant_url, mock_image
+    ):
+        extra_volume = {"name": "extra-volume", "emptyDir": {}}
+        _, crd = get_connector_and_crd(
+            spec_overrides={"container_extra": {"volumes": [extra_volume]}},
+        )
+
+        pod = get_connector_pod(crd, mock_tenant_url, mock_image)
+
+        assert pod.spec["volumes"] == [
+            {"name": "twingate-socket", "emptyDir": {}},
+            extra_volume,
+        ]


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/604

## Changes
- Add `livenessProbe` and `readinessProbe` to `TwingateConnector.spec.container`
- Set `readOnlyRootFilesystem` in `securityContext` to `True` by default. Also, add `volumes` and `volumeMounts`