### PR TITLE
feat: Supporting adding default tags on Twingate Resource

### DIFF
--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -259,9 +259,8 @@ class TwingateResourceAPIs:
         is_browser_shortcut_enabled: bool,
         remote_network_id: str,
         security_policy_id: str | None,
-        protocols: ResourceProtocols,
+        protocols: dict[str, Any],
         tags: list[dict[str, str]],
-        **_kwargs,
     ) -> Resource:
         result = self.execute_mutation(
             "resourceCreate",
@@ -293,7 +292,6 @@ class TwingateResourceAPIs:
         security_policy_id: str | None,
         protocols: ResourceProtocols,
         tags: list[dict[str, str]],
-        **_kwargs,
     ) -> Resource | None:
         result = self.execute_mutation(
             "resourceUpdate",

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -8,7 +8,7 @@ from pydantic.alias_generators import to_camel
 
 from app.api.exceptions import GraphQLMutationError
 from app.api.protocol import TwingateClientProtocol
-from app.crds import K8sMetadata, ProtocolPolicy, ResourceSpec
+from app.crds import ProtocolPolicy, ResourceSpec
 
 
 class ResourceAddress(BaseModel):
@@ -250,57 +250,65 @@ class TwingateResourceAPIs:
             return None
 
     def resource_create(
-        self: TwingateClientProtocol, resource: ResourceSpec, k8s_metadata: K8sMetadata
+        self: TwingateClientProtocol,
+        *,
+        name: str,
+        address: str,
+        alias: str | None,
+        is_visible: bool,
+        is_browser_shortcut_enabled: bool,
+        remote_network_id: str,
+        security_policy_id: str | None,
+        protocols: ResourceProtocols,
+        tags: list[dict[str, str]],
+        **_kwargs,
     ) -> Resource:
         result = self.execute_mutation(
             "resourceCreate",
             MUT_CREATE_RESOURCE,
             variable_values={
-                "name": resource.name,
-                "address": resource.address,
-                "alias": resource.alias,
-                "isVisible": resource.is_visible,
-                "isBrowserShortcutEnabled": resource.is_browser_shortcut_enabled,
-                "remoteNetworkId": resource.remote_network_id,
-                "securityPolicyId": resource.security_policy_id,
-                "protocols": resource.protocols.model_dump(by_alias=True),
-                "tags": (
-                    [
-                        {"key": key, "value": value}
-                        for key, value in k8s_metadata.labels.items()
-                    ]
-                    if resource.sync_labels
-                    else []
-                ),
+                "name": name,
+                "address": address,
+                "alias": alias,
+                "isVisible": is_visible,
+                "isBrowserShortcutEnabled": is_browser_shortcut_enabled,
+                "remoteNetworkId": remote_network_id,
+                "securityPolicyId": security_policy_id,
+                "protocols": protocols,
+                "tags": tags,
             },
         )
-
         return Resource(**result["entity"])
 
     def resource_update(
-        self: TwingateClientProtocol, resource: ResourceSpec, k8s_metadata: K8sMetadata
+        self: TwingateClientProtocol,
+        *,
+        id: str,
+        name: str,
+        address: str,
+        alias: str | None,
+        is_visible: bool,
+        is_browser_shortcut_enabled: bool,
+        remote_network_id: str,
+        security_policy_id: str | None,
+        protocols: ResourceProtocols,
+        tags: list[dict[str, str]],
+        **_kwargs,
     ) -> Resource | None:
         result = self.execute_mutation(
             "resourceUpdate",
             MUT_UPDATE_RESOURCE,
             variable_values={
-                "id": resource.id,
-                "name": resource.name,
-                "address": resource.address,
-                "alias": resource.alias,
-                "isVisible": resource.is_visible,
-                "isBrowserShortcutEnabled": resource.is_browser_shortcut_enabled,
-                "remoteNetworkId": resource.remote_network_id,
-                "securityPolicyId": resource.security_policy_id,
-                "protocols": resource.protocols.model_dump(by_alias=True),
-                "tags": (
-                    [
-                        {"key": key, "value": value}
-                        for key, value in k8s_metadata.labels.items()
-                    ]
-                    if resource.sync_labels
-                    else []
-                ),
+                "id": id,
+                "name": name,
+                "address": address,
+                "alias": alias,
+                "isVisible": is_visible,
+                "isBrowserShortcutEnabled": is_browser_shortcut_enabled,
+                "remoteNetworkId": remote_network_id,
+                "securityPolicyId": security_policy_id,
+                "protocols": protocols,
+                "tags": tags,
             },
         )
         return Resource(**result["entity"])

--- a/app/api/tests/test_client_resources.py
+++ b/app/api/tests/test_client_resources.py
@@ -195,7 +195,9 @@ class TestTwingateResourceAPIs:
             ],
         )
         result = api_client.resource_create(
-            **crd.to_graphql_arguments(labels=resource.to_metadata_labels())
+            **crd.to_graphql_arguments(
+                labels=resource.to_metadata_labels(), exclude={"id"}
+            )
         )
         assert result == resource
 
@@ -227,7 +229,9 @@ class TestTwingateResourceAPIs:
             GraphQLMutationError, match="resourceCreate mutation failed."
         ):
             api_client.resource_create(
-                **crd.to_graphql_arguments(labels=resource.to_metadata_labels())
+                **crd.to_graphql_arguments(
+                    labels=resource.to_metadata_labels(), exclude={"id"}
+                )
             )
 
     def test_resource_update(

--- a/app/crds.py
+++ b/app/crds.py
@@ -143,9 +143,12 @@ class ResourceSpec(BaseModel):
 
         return self
 
-    def to_graphql_arguments(self, labels: dict[str, str]) -> dict[str, Any]:
+    def to_graphql_arguments(
+        self, *, labels: dict[str, str], exclude: set[str] | None = None
+    ) -> dict[str, Any]:
+        exclude = exclude or set()
         return {
-            **self.model_dump(exclude={"sync_labels"}),
+            **self.model_dump(exclude=exclude | {"sync_labels"}),
             "protocols": self.protocols.model_dump(by_alias=True),
             "tags": [{"key": key, "value": value} for key, value in labels.items()]
             if self.sync_labels

--- a/app/crds.py
+++ b/app/crds.py
@@ -145,7 +145,7 @@ class ResourceSpec(BaseModel):
 
     def to_graphql_arguments(self, labels: dict[str, str]) -> dict[str, Any]:
         return {
-            **self.model_dump(exclude=["sync_labels"]),
+            **self.model_dump(exclude={"sync_labels"}),
             "protocols": self.protocols.model_dump(by_alias=True),
             "tags": [{"key": key, "value": value} for key, value in labels.items()]
             if self.sync_labels

--- a/app/crds.py
+++ b/app/crds.py
@@ -143,6 +143,15 @@ class ResourceSpec(BaseModel):
 
         return self
 
+    def to_graphql_arguments(self, labels: dict[str, str]) -> dict[str, Any]:
+        return {
+            **self.model_dump(exclude=["sync_labels"]),
+            "protocols": self.protocols.model_dump(by_alias=True),
+            "tags": [{"key": key, "value": value} for key, value in labels.items()]
+            if self.sync_labels
+            else [],
+        }
+
 
 class TwingateResourceCRD(BaseK8sModel):
     model_config = ConfigDict(frozen=True, populate_by_name=True, extra="allow")

--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -14,7 +14,7 @@ def twingate_resource_create(body, labels, spec, memo, logger, patch, **kwargs):
     client = TwingateAPIClient(memo.twingate_settings, logger=logger)
     labels = {
         tag["name"]: tag["value"]
-        for tag in memo.twingate_settings.default_resource_tags_dict
+        for tag in memo.twingate_settings.default_resource_tags
     } | dict(labels)
     graphql_arguments = resource.to_graphql_arguments(labels=labels, exclude={"id"})
 
@@ -51,7 +51,7 @@ def twingate_resource_update(labels, spec, diff, status, memo, logger, **kwargs)
     crd = ResourceSpec(**spec)
     labels = {
         tag["name"]: tag["value"]
-        for tag in memo.twingate_settings.default_resource_tags_dict
+        for tag in memo.twingate_settings.default_resource_tags
     } | dict(labels)
     graphql_arguments = crd.to_graphql_arguments(labels=labels)
 
@@ -92,7 +92,7 @@ def twingate_resource_sync(labels, spec, status, memo, logger, patch, **kwargs):
     crd = ResourceSpec(**spec)
     labels = {
         tag["name"]: tag["value"]
-        for tag in memo.twingate_settings.default_resource_tags_dict
+        for tag in memo.twingate_settings.default_resource_tags
     } | dict(labels)
     if resource_id := crd.id:
         logger.info("Checking resource %s is up to date...", resource_id)

--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -3,20 +3,27 @@ from datetime import timedelta
 import kopf
 
 from app.api import TwingateAPIClient
-from app.crds import K8sMetadata, ResourceSpec
+from app.crds import ResourceSpec
 from app.handlers.base import fail, success
 
 
 @kopf.on.create("twingateresource")
-def twingate_resource_create(body, meta, spec, memo, logger, patch, **kwargs):
-    logger.info("Got a create request: %s. Metadata: %s", spec, meta)
-    k8s_metadata = K8sMetadata(**meta)
+def twingate_resource_create(body, labels, spec, memo, logger, patch, **kwargs):
+    logger.info("Got a create request: %s. Labels: %s", spec, labels)
     resource = ResourceSpec(**spec)
     client = TwingateAPIClient(memo.twingate_settings, logger=logger)
+    labels = {
+        **{
+            tag["name"]: tag["value"]
+            for tag in memo.twingate_settings.default_resource_tags
+        },
+        **dict(labels),
+    }
+    graphql_arguments = resource.to_graphql_arguments(labels=labels)
 
     # Support importing existing resources - if `id` already exist we assume it's already created
     if resource.id:
-        resource = client.resource_update(resource, k8s_metadata)
+        resource = client.resource_update(**graphql_arguments)
         kopf.info(body, reason="Success", message=f"Imported {resource.id}")
         return success(
             twingate_id=resource.id,
@@ -25,7 +32,7 @@ def twingate_resource_create(body, meta, spec, memo, logger, patch, **kwargs):
             message="Resource id already present - assuming an import of an existing resource.",
         )
 
-    resource = client.resource_create(resource, k8s_metadata)
+    resource = client.resource_create(**graphql_arguments)
     patch.spec["id"] = resource.id
     kopf.info(body, reason="Success", message=f"Created on Twingate as {resource.id}")
     return success(
@@ -36,17 +43,24 @@ def twingate_resource_create(body, meta, spec, memo, logger, patch, **kwargs):
 
 
 @kopf.on.update("twingateresource")
-def twingate_resource_update(meta, spec, diff, status, memo, logger, **kwargs):
+def twingate_resource_update(labels, spec, diff, status, memo, logger, **kwargs):
     logger.info(
-        "Got TwingateResource update request: %s. Metadata: %s. Diff: %s. Status: %s.",
+        "Got TwingateResource update request: %s. Labels: %s. Diff: %s. Status: %s.",
         spec,
-        meta,
+        labels,
         diff,
         status,
     )
-
-    k8s_metadata = K8sMetadata(**meta)
     crd = ResourceSpec(**spec)
+    labels = {
+        **{
+            tag["name"]: tag["value"]
+            for tag in memo.twingate_settings.default_resource_tags
+        },
+        **dict(labels),
+    }
+    graphql_arguments = crd.to_graphql_arguments(labels=labels)
+
     if not crd.id:
         return fail(error="Resource ID is missing in the spec")
 
@@ -56,7 +70,7 @@ def twingate_resource_update(meta, spec, diff, status, memo, logger, **kwargs):
 
     logger.info("Updating resource %s", crd.id)
     client = TwingateAPIClient(memo.twingate_settings, logger=logger)
-    resource = client.resource_update(crd, k8s_metadata)
+    resource = client.resource_update(**graphql_arguments)
     logger.info("Got resource %s", resource)
     return success(
         twingate_id=resource.id,
@@ -80,25 +94,32 @@ def twingate_resource_delete(spec, status, memo, logger, **kwargs):
 @kopf.timer(
     "twingateresource", interval=timedelta(hours=10).seconds, initial_delay=60, idle=60
 )
-def twingate_resource_sync(meta, spec, status, memo, logger, patch, **kwargs):
-    k8s_metadata = K8sMetadata(**meta)
+def twingate_resource_sync(labels, spec, status, memo, logger, patch, **kwargs):
     crd = ResourceSpec(**spec)
+    labels = {
+        **{
+            tag["name"]: tag["value"]
+            for tag in memo.twingate_settings.default_resource_tags
+        },
+        **dict(labels),
+    }
     if resource_id := crd.id:
         logger.info("Checking resource %s is up to date...", resource_id)
         client = TwingateAPIClient(memo.twingate_settings, logger=logger)
         if resource := client.get_resource(resource_id):
             logger.info("Got resource %s", resource)
             if not (
-                resource.is_matching_spec(crd)
-                and resource.is_matching_labels(k8s_metadata.labels)
+                resource.is_matching_spec(crd) and resource.is_matching_labels(labels)
             ):
                 logger.info("Resource %s is out of date, updating...", resource_id)
-                client.resource_update(crd, k8s_metadata)
+                client.resource_update(**crd.to_graphql_arguments(labels=labels))
         else:
             # Resource was deleted, recreate it
             logger.info("Resource %s was deleted, recreating...", resource_id)
             crd_without_id = crd.model_copy(update={"id": None})
-            resource = client.resource_create(crd_without_id, k8s_metadata)
+            resource = client.resource_create(
+                **crd_without_id.to_graphql_arguments(labels=labels)
+            )
             patch.spec["id"] = resource.id
             return success(
                 twingate_id=resource.id,

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -31,14 +31,14 @@ def mock_k8s_metadata():
 
 
 @pytest.fixture
-def mock_memo_with_default_resource_tags_dict():
+def mock_memo_with_default_resource_tags():
     return MagicMock(
         twingate_settings=TwingateOperatorSettings(
             network="slug",
             host="test.com",
             api_key="test_key",
             remote_network_id="UmVtb3RlTmV0d29yazoxMjMK",
-            default_resource_tags_dict=[
+            default_resource_tags=[
                 {
                     "name": "managed_by",
                     "value": "test",
@@ -60,7 +60,7 @@ class TestResourceCreateHandler:
         kopf_info_mock,
         mock_api_client,
         mock_k8s_metadata,
-        mock_memo_with_default_resource_tags_dict,
+        mock_memo_with_default_resource_tags,
     ):
         resource = resource_factory()
         resource_spec = resource.to_spec(id=None)
@@ -76,7 +76,7 @@ class TestResourceCreateHandler:
             body="",
             labels=mock_k8s_metadata["labels"],
             spec=spec,
-            memo=mock_memo_with_default_resource_tags_dict,
+            memo=mock_memo_with_default_resource_tags,
             logger=logger_mock,
             patch=patch_mock,
         )
@@ -149,7 +149,7 @@ class TestResourceUpdateHandler:
         self,
         mock_api_client,
         mock_k8s_metadata,
-        mock_memo_with_default_resource_tags_dict,
+        mock_memo_with_default_resource_tags,
     ):
         rid = "UmVzb3VyY2U6OTMxODE3"
         spec = new = {
@@ -178,7 +178,7 @@ class TestResourceUpdateHandler:
             spec,
             diff,
             status,
-            mock_memo_with_default_resource_tags_dict,
+            mock_memo_with_default_resource_tags,
             logger_mock,
         )
         assert result == {
@@ -377,7 +377,7 @@ class TestResourceSyncTimer:
         resource_factory,
         mock_api_client,
         mock_k8s_metadata,
-        mock_memo_with_default_resource_tags_dict,
+        mock_memo_with_default_resource_tags,
     ):
         resource = resource_factory()
         resource_spec = resource.to_spec()
@@ -399,7 +399,7 @@ class TestResourceSyncTimer:
             mock_k8s_metadata["labels"],
             resource_spec.model_dump(by_alias=True),
             status,
-            mock_memo_with_default_resource_tags_dict,
+            mock_memo_with_default_resource_tags,
             logger_mock,
             patch_mock,
         )
@@ -416,7 +416,7 @@ class TestResourceSyncTimer:
         resource_factory,
         mock_api_client,
         mock_k8s_metadata,
-        mock_memo_with_default_resource_tags_dict,
+        mock_memo_with_default_resource_tags,
     ):
         resource = resource_factory()
         resource_spec = resource.to_spec()
@@ -439,7 +439,7 @@ class TestResourceSyncTimer:
             mock_k8s_metadata["labels"],
             resource_spec.model_dump(by_alias=True),
             status,
-            mock_memo_with_default_resource_tags_dict,
+            mock_memo_with_default_resource_tags,
             logger_mock,
             patch_mock,
         )

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -37,6 +37,7 @@ def mock_memo_with_default_resource_tags():
             network="slug",
             host="test.com",
             api_key="test_key",
+            remote_network_id="UmVtb3RlTmV0d29yazoxMjMK",
             default_resource_tags=[
                 {
                     "name": "default",

--- a/app/settings.py
+++ b/app/settings.py
@@ -39,7 +39,7 @@ class TwingateOperatorSettings(BaseSettings):
     remote_network_id: GlobalID = NULL_RN_ID
     remote_network_name: str | None = None
     host: str = "twingate.com"
-    default_resource_tags: list[dict[str, str]] = []
+    default_resource_tags_dict: list[dict[str, str]] = []
     kopf_watching_server_timeout: int | None = None
     kopf_watching_client_timeout: int | None = None
     kopf_watching_connect_timeout: int | None = None

--- a/app/settings.py
+++ b/app/settings.py
@@ -39,6 +39,7 @@ class TwingateOperatorSettings(BaseSettings):
     remote_network_id: GlobalID = NULL_RN_ID
     remote_network_name: str | None = None
     host: str = "twingate.com"
+    default_resource_tags: list[dict[str, str]] = []
     kopf_watching_server_timeout: int | None = None
     kopf_watching_client_timeout: int | None = None
     kopf_watching_connect_timeout: int | None = None

--- a/app/settings.py
+++ b/app/settings.py
@@ -39,7 +39,7 @@ class TwingateOperatorSettings(BaseSettings):
     remote_network_id: GlobalID = NULL_RN_ID
     remote_network_name: str | None = None
     host: str = "twingate.com"
-    default_resource_tags_dict: list[dict[str, str]] = []
+    default_resource_tags: list[dict[str, str]] = []
     kopf_watching_server_timeout: int | None = None
     kopf_watching_client_timeout: int | None = None
     kopf_watching_connect_timeout: int | None = None

--- a/app/tests/test_crds_resource.py
+++ b/app/tests/test_crds_resource.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.crds import TwingateResourceCRD
+from app.crds import ResourceSpec, TwingateResourceCRD
 
 
 @pytest.fixture
@@ -177,3 +177,34 @@ def test_resourceprotocol_ports_validation():
                 },
             },
         )
+
+
+def test_resource_spec_to_graphql_arguments(sample_resource_object):
+    resource_spec = ResourceSpec(**sample_resource_object["spec"], sync_labels=True)
+    graphql_arguments = resource_spec.to_graphql_arguments(labels={"key": "value"})
+
+    assert graphql_arguments == {
+        "id": "UmVzb3VyY2U6OTM3Mzkw",
+        "name": "My K8S Resource",
+        "address": "my.default.cluster.local",
+        "alias": None,
+        "remote_network_id": "UmVtb3RlTmV0d29yazoxMjMK",
+        "security_policy_id": None,
+        "is_visible": True,
+        "is_browser_shortcut_enabled": True,
+        "protocols": {
+            "allowIcmp": True,
+            "tcp": {"policy": "RESTRICTED", "ports": [{"start": 80, "end": 80}]},
+            "udp": {"policy": "ALLOW_ALL", "ports": []},
+        },
+        "tags": [{"key": "key", "value": "value"}],
+    }
+
+
+def test_resource_spec_to_graphql_arguments_when_sync_labels_disabled(
+    sample_resource_object,
+):
+    resource_spec = ResourceSpec(**sample_resource_object["spec"], sync_labels=False)
+    graphql_arguments = resource_spec.to_graphql_arguments(labels={"key": "value"})
+
+    assert graphql_arguments["tags"] == []

--- a/app/tests/test_crds_resource.py
+++ b/app/tests/test_crds_resource.py
@@ -181,10 +181,11 @@ def test_resourceprotocol_ports_validation():
 
 def test_resource_spec_to_graphql_arguments(sample_resource_object):
     resource_spec = ResourceSpec(**sample_resource_object["spec"], sync_labels=True)
-    graphql_arguments = resource_spec.to_graphql_arguments(labels={"key": "value"})
+    graphql_arguments = resource_spec.to_graphql_arguments(
+        labels={"key": "value"}, exclude={"id"}
+    )
 
     assert graphql_arguments == {
-        "id": "UmVzb3VyY2U6OTM3Mzkw",
         "name": "My K8S Resource",
         "address": "my.default.cluster.local",
         "alias": None,

--- a/deploy/test/golden/apikey.golden.yaml
+++ b/deploy/test/golden/apikey.golden.yaml
@@ -132,6 +132,8 @@ spec:
             value: <network slug>
           - name: TWINGATE_HOST
             value: twingate.com
+          - name: TWINGATE_DEFAULT_RESOURCE_TAGS
+            value: "[]"
           - name: TWINGATE_REMOTE_NETWORK_ID
             value: <remote network id>
         livenessProbe:

--- a/deploy/test/golden/defaultResourceTags.golden.yaml
+++ b/deploy/test/golden/defaultResourceTags.golden.yaml
@@ -12,6 +12,21 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: twingate-operator/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-twingate-operator
+  namespace: default
+  labels:
+    helm.sh/chart: twingate-operator-major.minor.patch-test
+    app.kubernetes.io/name: twingate-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TWINGATE_API_KEY: PGFwaSBrZXk+
+---
 # Source: twingate-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -111,14 +126,14 @@ spec:
           - name: TWINGATE_API_KEY
             valueFrom:
               secretKeyRef:
-                name: my-secret
-                key: MY_TWINGATE_API_KEY
+                name: test-twingate-operator
+                key: TWINGATE_API_KEY
           - name: TWINGATE_NETWORK
             value: <network slug>
           - name: TWINGATE_HOST
             value: twingate.com
           - name: TWINGATE_DEFAULT_RESOURCE_TAGS
-            value: "[]"
+            value: "[{\"name\":\"cluster\",\"value\":\"test-cluster\"},{\"name\":\"owner\",\"value\":\"eran\"}]"
           - name: TWINGATE_REMOTE_NETWORK_ID
             value: <remote network id>
         livenessProbe:

--- a/deploy/test/golden/defaultResourceTags.yaml
+++ b/deploy/test/golden/defaultResourceTags.yaml
@@ -1,0 +1,9 @@
+twingateOperator:
+  apiKey: "<api key>"
+  network: "<network slug>"
+  remoteNetworkId: "<remote network id>"
+  defaultResourceTags:
+    - name: "cluster"
+      value: "test-cluster"
+    - name: "owner"
+      value: "eran"

--- a/deploy/test/golden/existingRemoteNetworkIdSecret.golden.yaml
+++ b/deploy/test/golden/existingRemoteNetworkIdSecret.golden.yaml
@@ -117,6 +117,8 @@ spec:
             value: <network slug>
           - name: TWINGATE_HOST
             value: twingate.com
+          - name: TWINGATE_DEFAULT_RESOURCE_TAGS
+            value: "[]"
           - name: TWINGATE_REMOTE_NETWORK_ID
             valueFrom:
               secretKeyRef:

--- a/deploy/test/golden/extraEnvVars.golden.yaml
+++ b/deploy/test/golden/extraEnvVars.golden.yaml
@@ -132,6 +132,8 @@ spec:
             value: <network slug>
           - name: TWINGATE_HOST
             value: twingate.com
+          - name: TWINGATE_DEFAULT_RESOURCE_TAGS
+            value: "[]"
           - name: TWINGATE_REMOTE_NETWORK_ID
             value: <remote network id>
           - name: FOO

--- a/deploy/test/golden/logVerbosity.golden.yaml
+++ b/deploy/test/golden/logVerbosity.golden.yaml
@@ -133,6 +133,8 @@ spec:
             value: <network slug>
           - name: TWINGATE_HOST
             value: twingate.com
+          - name: TWINGATE_DEFAULT_RESOURCE_TAGS
+            value: "[]"
           - name: TWINGATE_REMOTE_NETWORK_ID
             value: <remote network id>
         livenessProbe:

--- a/deploy/test/golden/podLabels.golden.yaml
+++ b/deploy/test/golden/podLabels.golden.yaml
@@ -133,6 +133,8 @@ spec:
             value: <network slug>
           - name: TWINGATE_HOST
             value: twingate.com
+          - name: TWINGATE_DEFAULT_RESOURCE_TAGS
+            value: "[]"
           - name: TWINGATE_REMOTE_NETWORK_ID
             value: <remote network id>
         livenessProbe:

--- a/deploy/test/golden/priorityClassName.golden.yaml
+++ b/deploy/test/golden/priorityClassName.golden.yaml
@@ -133,6 +133,8 @@ spec:
             value: <network slug>
           - name: TWINGATE_HOST
             value: twingate.com
+          - name: TWINGATE_DEFAULT_RESOURCE_TAGS
+            value: "[]"
           - name: TWINGATE_REMOTE_NETWORK_ID
             value: <remote network id>
         livenessProbe:

--- a/deploy/test/golden/remoteNetworkName.golden.yaml
+++ b/deploy/test/golden/remoteNetworkName.golden.yaml
@@ -132,6 +132,8 @@ spec:
             value: <network slug>
           - name: TWINGATE_HOST
             value: twingate.com
+          - name: TWINGATE_DEFAULT_RESOURCE_TAGS
+            value: "[]"
           - name: TWINGATE_REMOTE_NETWORK_NAME
             value: <remote network name>
         livenessProbe:

--- a/deploy/twingate-operator/templates/deployment.yaml
+++ b/deploy/twingate-operator/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
             value: {{ required "Network name required" .Values.twingateOperator.network }}
           - name: TWINGATE_HOST
             value: {{ .Values.twingateOperator.host | default "twingate.com" }}
+          - name: TWINGATE_DEFAULT_RESOURCE_TAGS
+            value: {{ .Values.twingateOperator.defaultResourceTags | default list | toJson | quote }}
           {{- if .Values.twingateOperator.existingRemoteNetworkIdSecret }}
           - name: TWINGATE_REMOTE_NETWORK_ID
             valueFrom:

--- a/deploy/twingate-operator/values.schema.json
+++ b/deploy/twingate-operator/values.schema.json
@@ -147,6 +147,20 @@
                         "verbose",
                         "debug"
                     ]
+                },
+                "defaultResourceTags": {
+                    "type": "array",
+                    "description": "Array with default resource tags to be added to the operator",
+                    "default": [],
+                    "items": {
+                        "type": "object",
+                        "required": ["name", "value"],
+                        "properties": {
+                          "name": { "type": "string" },
+                          "value": { "type": "string" }
+                        },
+                        "additionalProperties": false
+                    }
                 }
             },
             "examples": [{

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -18,6 +18,11 @@ twingateOperator: {}
 #  remoteNetworkName: "<remote network name>"
 #  logFormat: "plain|full|json"
 #  logVerbosity: "quiet|verbose|debug"
+#  defaultResourceTags:
+#    - name: "tag1"
+#      value: "value1"
+#    - name: "tag2"
+#      value: "value2"
 
 
 image:


### PR DESCRIPTION
## Changes
- Add default tags to Twingate Resource based on `TWINGATE_DEFAULT_RESOURCE_TAGS` envvar set on the Operator.
- Refactor Resource client API code
