### PR TITLE
fix: `defaultResourceTags` to match labels schema

### DIFF
--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -12,10 +12,7 @@ def twingate_resource_create(body, labels, spec, memo, logger, patch, **kwargs):
     logger.info("Got a create request: %s. Labels: %s", spec, labels)
     resource = ResourceSpec(**spec)
     client = TwingateAPIClient(memo.twingate_settings, logger=logger)
-    labels = {
-        tag["name"]: tag["value"]
-        for tag in memo.twingate_settings.default_resource_tags
-    } | dict(labels)
+    labels = memo.twingate_settings.default_resource_tags | dict(labels)
     graphql_arguments = resource.to_graphql_arguments(labels=labels, exclude={"id"})
 
     # Support importing existing resources - if `id` already exist we assume it's already created
@@ -49,10 +46,7 @@ def twingate_resource_update(labels, spec, diff, status, memo, logger, **kwargs)
         status,
     )
     crd = ResourceSpec(**spec)
-    labels = {
-        tag["name"]: tag["value"]
-        for tag in memo.twingate_settings.default_resource_tags
-    } | dict(labels)
+    labels = memo.twingate_settings.default_resource_tags | dict(labels)
     graphql_arguments = crd.to_graphql_arguments(labels=labels)
 
     if not crd.id:
@@ -90,10 +84,7 @@ def twingate_resource_delete(spec, status, memo, logger, **kwargs):
 )
 def twingate_resource_sync(labels, spec, status, memo, logger, patch, **kwargs):
     crd = ResourceSpec(**spec)
-    labels = {
-        tag["name"]: tag["value"]
-        for tag in memo.twingate_settings.default_resource_tags
-    } | dict(labels)
+    labels = memo.twingate_settings.default_resource_tags | dict(labels)
     if resource_id := crd.id:
         logger.info("Checking resource %s is up to date...", resource_id)
         client = TwingateAPIClient(memo.twingate_settings, logger=logger)

--- a/app/settings.py
+++ b/app/settings.py
@@ -39,7 +39,7 @@ class TwingateOperatorSettings(BaseSettings):
     remote_network_id: GlobalID = NULL_RN_ID
     remote_network_name: str | None = None
     host: str = "twingate.com"
-    default_resource_tags: list[dict[str, str]] = []
+    default_resource_tags: dict[str, str] = {}
     kopf_watching_server_timeout: int | None = None
     kopf_watching_client_timeout: int | None = None
     kopf_watching_connect_timeout: int | None = None

--- a/deploy/test/golden/defaultResourceTags.golden.yaml
+++ b/deploy/test/golden/defaultResourceTags.golden.yaml
@@ -133,7 +133,7 @@ spec:
           - name: TWINGATE_HOST
             value: twingate.com
           - name: TWINGATE_DEFAULT_RESOURCE_TAGS
-            value: "[{\"name\":\"cluster\",\"value\":\"test-cluster\"},{\"name\":\"owner\",\"value\":\"eran\"}]"
+            value: "{\"cluster\":\"test-cluster\",\"owner\":\"eran\"}"
           - name: TWINGATE_REMOTE_NETWORK_ID
             value: <remote network id>
         livenessProbe:

--- a/deploy/test/golden/defaultResourceTags.yaml
+++ b/deploy/test/golden/defaultResourceTags.yaml
@@ -3,7 +3,5 @@ twingateOperator:
   network: "<network slug>"
   remoteNetworkId: "<remote network id>"
   defaultResourceTags:
-    - name: "cluster"
-      value: "test-cluster"
-    - name: "owner"
-      value: "eran"
+    cluster: "test-cluster"
+    owner: "eran"

--- a/deploy/twingate-operator/values.schema.json
+++ b/deploy/twingate-operator/values.schema.json
@@ -149,17 +149,11 @@
                     ]
                 },
                 "defaultResourceTags": {
-                    "type": "array",
-                    "description": "Array with default resource tags to be added to the operator",
-                    "default": [],
-                    "items": {
-                        "type": "object",
-                        "required": ["name", "value"],
-                        "properties": {
-                          "name": { "type": "string" },
-                          "value": { "type": "string" }
-                        },
-                        "additionalProperties": false
+                    "type": "object",
+                    "description": "Map of string keys and values that will be used as tags in every TwingateResource object managed by the operator",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
                     }
                 }
             },

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -19,10 +19,8 @@ twingateOperator: {}
 #  logFormat: "plain|full|json"
 #  logVerbosity: "quiet|verbose|debug"
 #  defaultResourceTags:
-#    - name: "tag1"
-#      value: "value1"
-#    - name: "tag2"
-#      value: "value2"
+#    tag1: value_for_tag1
+#    tag2: value_for_tag2
 
 
 image:


### PR DESCRIPTION
## Changes

Changed `defaultResourceTags` schema in `values.yaml` to match how labels are defined in k8s - as an object rather than a list of objects. (see example: https://github.com/instrumenta/kubernetes-json-schema/blob/master/v1.7.8/_definitions.json#L528)

