### PR TITLE
fix: Skip `twingate_resource_update` handler when `spec.id` is added

### DIFF
--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -52,8 +52,8 @@ def twingate_resource_update(labels, spec, diff, status, memo, logger, **kwargs)
     if not crd.id:
         return fail(error="Resource ID is missing in the spec")
 
-    # Check if just "id" was added - means `create` just ran
-    if len(diff) == 1 and diff[0][:3] == ("add", ("id",), None):
+    # Check if just "spec.id" was added - means `create` just ran
+    if len(diff) == 1 and diff[0][:3] == ("add", ("spec", "id"), None):
         return success(twingate_id=crd.id, message="No update required")
 
     logger.info("Updating resource %s", crd.id)
@@ -95,6 +95,11 @@ def twingate_resource_sync(labels, spec, status, memo, logger, patch, **kwargs):
             ):
                 logger.info("Resource %s is out of date, updating...", resource_id)
                 client.resource_update(**crd.to_graphql_arguments(labels=labels))
+                return success(
+                    twingate_id=resource.id,
+                    created_at=resource.created_at.isoformat(),
+                    updated_at=resource.updated_at.isoformat(),
+                )
         else:
             # Resource was deleted, recreate it
             logger.info("Resource %s was deleted, recreating...", resource_id)

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -164,7 +164,7 @@ class TestResourceUpdateHandler:
             "address": "my.default.cluster.local",
             "name": "new-name",
         }
-        diff = (("change", ("name"), "My K8S Resource", "new-name"),)
+        diff = (("change", ("spec", "name"), "My K8S Resource", "new-name"),)
         status = {
             "twingate_resource_create": {
                 "twingate_id": rid,
@@ -237,7 +237,7 @@ class TestResourceUpdateHandler:
             "address": "my.default.cluster.local",
             "name": "new-name",
         }
-        diff = (("add", ("id",), None, rid),)
+        diff = (("add", ("spec", "id"), None, rid),)
         status = {
             "twingate_resource_create": {
                 "twingate_id": rid,


### PR DESCRIPTION
## Changes
- A regression bug was introduced when we updated `twingate_resource_update` handler to detect change on the whole object instead of the `spec` field in this [PR](https://github.com/Twingate/kubernetes-operator/commit/e77773d38246bd1352bf6dd6af6271a50d8d13da#diff-dab0a0f836e493ffe8dc057c0f1a4b6c4914c67865f7747b06c0c170068a8075L37-L38). As a result, the `diff` structure is different and needs to be updated to match the new structure.
- Return `success` result when resource is updated in `twingate_resource_sync` handler. This is an improvement for better status logging.