### PR TITLE
fix: Add client_timeout setting to prevent operator disconnect

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,8 +33,9 @@ def startup(
     logger.info("Operator is starting up...")
 
     # Fixes issue where operator stops detecting changes (see https://github.com/nolar/kopf/issues/1120)
+    settings.watching.connect_timeout = 60
     settings.watching.server_timeout = 5 * 60
-    settings.watching.client_timeout = 5 * 60 + 1
+    settings.watching.client_timeout = settings.watching.server_timeout + 1
 
     settings.persistence.finalizer = "twingate.com/finalizer"
     settings.persistence.diffbase_storage = TwingateAnnotationsDiffBaseStorage()

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ def startup(
 
     # Fixes issue where operator stops detecting changes (see https://github.com/nolar/kopf/issues/1120)
     settings.watching.server_timeout = 5 * 60
+    settings.watching.client_timeout = 5 * 60 + 1
 
     settings.persistence.finalizer = "twingate.com/finalizer"
     settings.persistence.diffbase_storage = TwingateAnnotationsDiffBaseStorage()


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #642 

## Changes

- Added `client_timeout` setting
