### PR TITLE
fix: Dont use a well known label name as selector

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -303,7 +303,7 @@ def twingate_connector_pod_reconciler(
     if crd.spec.image:
         # If we're on a fixed-image policy, image updates are handled by `twingate_connector_update`.
         # Here we only check for a drift (someone edited the deployment manually)
-        if k8s_pod_image != crd.spec.image:
+        if k8s_pod_image != str(crd.spec.image):
             logger.warning(
                 "Detected a drift between the Deployment image (%s) and the CRD image (%s)",
                 k8s_pod_image,

--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -57,8 +57,7 @@ def get_connector_deployment(
     # fmt: off
     pod_annotations = spec.pod_annotations
     pod_selector_labels = {
-        "app.kubernetes.io/name": "TwingateConnector",
-        "app.kubernetes.io/instance": name,
+        "connector.twingate.com/name": name,
     }
     pod_labels = spec.pod_labels | pod_selector_labels
 

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -708,5 +708,4 @@ class TestGetConnectorDeployment:
 
         assert pod_metadata["labels"] == labels | {
             "connector.twingate.com/name": crd.metadata.name,
-            "env": "test",
         }

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -707,6 +707,6 @@ class TestGetConnectorDeployment:
         pod_metadata = dep.spec["template"]["metadata"]
 
         assert pod_metadata["labels"] == labels | {
-            "app.kubernetes.io/name": "TwingateConnector",
-            "app.kubernetes.io/instance": crd.metadata.name,
+            "connector.twingate.com/name": crd.metadata.name,
+            "env": "test",
         }

--- a/examples/connector.yaml
+++ b/examples/connector.yaml
@@ -22,30 +22,30 @@ spec:
   podAnnotations:
     some/annotation: "some-value"
 ---
-#apiVersion: twingate.com/v1beta
-#kind: TwingateConnector
-#metadata:
-#  name: my-connector-auto-updating-image
-#  labels:
-#    app.kubernetes.io/name: test
-#spec:
-#  # Sets policy to check once a day at 00:00 (UTC) for a new version of the image based on
-#  # the version specifier "^1.0.0". If a new version is found, it will be deployed.
-#  # Version specifier uses NPM spec: https://github.com/npm/node-semver#ranges
-#  imagePolicy:
-#    provider: "dockerhub"
-#    schedule: "0 0 * * *"
-#    repository: twingate/connector
-#    version: "^1.0.0"
-#  containerExtra:
-#    resources:
-#      requests:
-#        cpu: 314m
-#        memory: 128Mi
-#      limits:
-#        cpu: 500m
-#        memory: 128Mi
-#  podExtra: {}
-#  podLabels: {}
-#  podAnnotations:
-#    some/annotation: "some-value"
+apiVersion: twingate.com/v1beta
+kind: TwingateConnector
+metadata:
+  name: my-connector-auto-updating-image
+  labels:
+    app.kubernetes.io/name: test
+spec:
+  # Sets policy to check once a day at 00:00 (UTC) for a new version of the image based on
+  # the version specifier "^1.0.0". If a new version is found, it will be deployed.
+  # Version specifier uses NPM spec: https://github.com/npm/node-semver#ranges
+  imagePolicy:
+    provider: "dockerhub"
+    schedule: "0 0 * * *"
+    repository: twingate/connector
+    version: "^1.0.0"
+  containerExtra:
+    resources:
+      requests:
+        cpu: 314m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 128Mi
+  podExtra: {}
+  podLabels: {}
+  podAnnotations:
+    some/annotation: "some-value"

--- a/examples/connector.yaml
+++ b/examples/connector.yaml
@@ -2,6 +2,8 @@ apiVersion: twingate.com/v1beta
 kind: TwingateConnector
 metadata:
   name: my-connector-fixed-image
+  labels:
+    app.kubernetes.io/name: test
 spec:
   # Sets policy to use the image "twingate/connector:latest" and never update it.
   image:
@@ -20,28 +22,30 @@ spec:
   podAnnotations:
     some/annotation: "some-value"
 ---
-apiVersion: twingate.com/v1beta
-kind: TwingateConnector
-metadata:
-  name: my-connector-auto-updating-image
-spec:
-  # Sets policy to check once a day at 00:00 (UTC) for a new version of the image based on
-  # the version specifier "^1.0.0". If a new version is found, it will be deployed.
-  # Version specifier uses NPM spec: https://github.com/npm/node-semver#ranges
-  imagePolicy:
-    provider: "dockerhub"
-    schedule: "0 0 * * *"
-    repository: twingate/connector
-    version: "^1.0.0"
-  containerExtra:
-    resources:
-      requests:
-        cpu: 314m
-        memory: 128Mi
-      limits:
-        cpu: 500m
-        memory: 128Mi
-  podExtra: {}
-  podLabels: {}
-  podAnnotations:
-    some/annotation: "some-value"
+#apiVersion: twingate.com/v1beta
+#kind: TwingateConnector
+#metadata:
+#  name: my-connector-auto-updating-image
+#  labels:
+#    app.kubernetes.io/name: test
+#spec:
+#  # Sets policy to check once a day at 00:00 (UTC) for a new version of the image based on
+#  # the version specifier "^1.0.0". If a new version is found, it will be deployed.
+#  # Version specifier uses NPM spec: https://github.com/npm/node-semver#ranges
+#  imagePolicy:
+#    provider: "dockerhub"
+#    schedule: "0 0 * * *"
+#    repository: twingate/connector
+#    version: "^1.0.0"
+#  containerExtra:
+#    resources:
+#      requests:
+#        cpu: 314m
+#        memory: 128Mi
+#      limits:
+#        cpu: 500m
+#        memory: 128Mi
+#  podExtra: {}
+#  podLabels: {}
+#  podAnnotations:
+#    some/annotation: "some-value"

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -20,6 +20,8 @@ def test_connector_flows(run_kopf, random_name_generator):
         kind: TwingateConnector
         metadata:
             name: {connector_name}
+            labels:
+              app.kubernetes.io/name: test
         spec:
             name: {connector_name}
             logLevel: 7
@@ -88,6 +90,8 @@ def test_connector_flows_image_change(run_kopf, random_name_generator):
         kind: TwingateConnector
         metadata:
             name: {connector_name}
+            labels:
+              app.kubernetes.io/name: test
         spec:
             name: {connector_name}
             hasStatusNotificationsEnabled: false
@@ -136,6 +140,8 @@ def test_connector_flows_deployment_gone_while_operator_down(
         kind: TwingateConnector
         metadata:
             name: {connector_name}
+            labels:
+              app.kubernetes.io/name: test
         spec:
             name: {connector_name}
             hasStatusNotificationsEnabled: false


### PR DESCRIPTION
## Related Tickets & Documents

Fixes #651 

## Changes

- The "reserved" name we use for connector label can't be a well-known name that might be used by user...