### PR TITLE
fix: Reconciler should only update k8s if there’s drift in image

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -304,7 +304,7 @@ def twingate_connector_pod_reconciler(
     if crd.spec.image:
         # If we're on a fixed-image policy, image updates are handled by `twingate_connector_update`.
         # Here we only check for a drift (someone edited the deployment manually)
-        if k8s_pod_image != crd.spec.image:
+        if k8s_pod_image != str(crd.spec.image):
             logger.warning(
                 "Detected a drift between the Deployment image (%s) and the CRD image (%s)",
                 k8s_pod_image,

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -324,7 +324,7 @@ class TestTwingateConnectorPodReconciler_Image:
         assert run.result == {"success": True, "ts": ANY}
         run.k8s_apps_client_mock.create_namespaced_deployment.assert_called_once()
 
-    def test_deployment_update(
+    def test_deployment_update_if_drift(
         self,
         get_connector_and_crd,
         kopf_handler_runner,
@@ -338,6 +338,31 @@ class TestTwingateConnectorPodReconciler_Image:
         run = kopf_handler_runner(twingate_connector_pod_reconciler, crd, MagicMock())
         assert run.result == {"success": True, "ts": ANY}
         run.k8s_apps_client_mock.replace_namespaced_deployment.assert_called_once()
+
+    def test_deployment_no_update_if_no_drift(
+        self,
+        get_connector_and_crd,
+        kopf_handler_runner,
+        k8s_core_client_mock,
+        k8s_apps_client_mock,
+    ):
+        connector, crd = get_connector_and_crd(
+            status={"twingate_connector_create": {"success": True}}, with_id=True
+        )
+
+        container_mock = MagicMock()
+        container_mock.image = "twingate/connector:1"
+
+        k8s_deployment_mock = MagicMock()
+        k8s_deployment_mock.spec.template.spec.containers = [container_mock]
+
+        k8s_apps_client_mock.read_namespaced_deployment.return_value = (
+            k8s_deployment_mock
+        )
+
+        run = kopf_handler_runner(twingate_connector_pod_reconciler, crd, MagicMock())
+        assert run.result == {"success": True, "ts": ANY}
+        run.k8s_apps_client_mock.replace_namespaced_deployment.assert_not_called()
 
 
 class TestTwingateConnectorPodReconciler_ImagePolicy:


### PR DESCRIPTION
## Changes

Reconciler was always calling k8s replace because image if statement was wrong.
