### PR TITLE
fix: Get resource should only return None if not found

### DIFF
--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -441,7 +441,7 @@ class TwingateResourceAPIs:
                     raise ValueError(f"Invalid Resource Type: {resource_type}")
         except TransportQueryError:
             self.logger.exception("Failed to get resource")
-            return None
+            raise
 
     def resource_create(
         self: TwingateClientProtocol, resource_type: ResourceType, **graphql_arguments

--- a/app/api/tests/test_client_resources.py
+++ b/app/api/tests/test_client_resources.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import orjson as json
 import pytest
 import responses
+from gql.transport.exceptions import TransportQueryError
 from pydantic_core._pydantic_core import ValidationError
 
 from app.api.client import GraphQLMutationError
@@ -210,7 +211,7 @@ class TestTwingateResourceAPIs:
         with pytest.raises(ValueError, match="Invalid Resource Type: InvalidResource"):
             api_client.get_resource(resource.id)
 
-    def test_get_resource_with_invalid_id_returns_none(
+    def test_get_resource_with_invalid_b64_id_raises(
         self, test_url, api_client, network_resource_factory, mocked_responses
     ):
         resource = network_resource_factory()
@@ -231,8 +232,8 @@ class TestTwingateResourceAPIs:
         """
 
         mocked_responses.post(test_url, status=200, body=failed_response)
-        result = api_client.get_resource(resource.id)
-        assert result is None
+        with pytest.raises(TransportQueryError):
+            api_client.get_resource(resource.id)
 
     def test_resource_create_with_network_type(self, api_client):
         api_client.network_resource_create = MagicMock()


### PR DESCRIPTION


## Changes

- `get_resource` should only return `None` if resource not found not if query is invalid or any other kind of error.
- Returning `None` in case of error can lead to resource_reconciler recreating the resource over and over unecessarily
