### PR TITLE
fix: allow_zero_version should be true

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ ignore = [
 convention = "google"
 
 [tool.semantic_release]
+allow_zero_version = true
 version_toml = [
     "pyproject.toml:tool.poetry.version",
 ]


### PR DESCRIPTION


## Changes

https://python-semantic-release.readthedocs.io/en/latest/upgrading/10-upgrade.html#default-configuration-changes

Default used to be `true` and changed to `false` in v10
