### PR TITLE
feat: Support creating `LoadBalancer` Service type for Kubernetes Resource

### DIFF
--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -32,6 +32,7 @@ def example_service_body():
         twingate.com/resource: "true"
         twingate.com/resource-alias: "myapp.internal"
     spec:
+      type: ClusterIP
       selector:
         app.kubernetes.io/name: MyApp
       ports:
@@ -52,7 +53,7 @@ def example_service_body():
 
 
 @pytest.fixture
-def example_gateway_service_body():
+def example_cluster_ip_gateway_service_body():
     yaml_str = """
     apiVersion: v1
     kind: Service
@@ -75,6 +76,39 @@ def example_gateway_service_body():
           protocol: TCP
           port: 443
           targetPort: https
+    """
+    return kopf.Body(yaml.safe_load(yaml_str))
+
+
+@pytest.fixture
+def example_load_balancer_gateway_service_body():
+    yaml_str = """
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: kubernetes-gateway
+      labels:
+        env: dev
+      annotations:
+        resource.twingate.com: "true"
+        resource.twingate.com/type: "Kubernetes"
+        resource.twingate.com/tlsSecret: "gateway-tls"
+        resource.twingate.com/alias: "gateway.default.svc.cluster.local"
+    spec:
+      selector:
+        app.kubernetes.io/name: gateway
+        app.kubernetes.io/instance: kubernetes
+      type: LoadBalancer
+      ports:
+        - name: https
+          protocol: TCP
+          port: 443
+          targetPort: https
+    status:
+      loadBalancer:
+        ingress:
+        - ip: 10.0.0.1
+          ipMode: VIP
     """
     return kopf.Body(yaml.safe_load(yaml_str))
 
@@ -147,13 +181,18 @@ class TestServiceToTwingateResource:
         assert result == expected
 
     def test_kubernetes_resource_type_annotation(
-        self, example_gateway_service_body, k8s_core_client_mock, k8s_tls_secret_mock
+        self,
+        example_cluster_ip_gateway_service_body,
+        k8s_core_client_mock,
+        k8s_tls_secret_mock,
     ):
         tls_object_name = "gateway-tls"
         namespace = "default"
         k8s_core_client_mock.read_namespaced_secret.return_value = k8s_tls_secret_mock
 
-        result = service_to_twingate_resource(example_gateway_service_body, namespace)
+        result = service_to_twingate_resource(
+            example_cluster_ip_gateway_service_body, namespace
+        )
         k8s_core_client_mock.read_namespaced_secret.assert_called_once_with(
             namespace=namespace, name=tls_object_name
         )
@@ -181,20 +220,22 @@ class TestServiceToTwingateResource:
         }
 
     def test_kubernetes_resource_type_annotation_without_tls_secret_annotation(
-        self, example_gateway_service_body
+        self, example_cluster_ip_gateway_service_body
     ):
-        example_gateway_service_body.metadata["annotations"][TLS_OBJECT_ANNOTATION] = (
-            None
-        )
+        example_cluster_ip_gateway_service_body.metadata["annotations"][
+            TLS_OBJECT_ANNOTATION
+        ] = None
 
         with pytest.raises(
             kopf.PermanentError,
             match="resource.twingate.com/tlsSecret annotation is not provided",
         ):
-            service_to_twingate_resource(example_gateway_service_body, "default")
+            service_to_twingate_resource(
+                example_cluster_ip_gateway_service_body, "default"
+            )
 
     def test_kubernetes_resource_type_annotation_without_k8s_secret_object(
-        self, example_gateway_service_body, k8s_core_client_mock
+        self, example_cluster_ip_gateway_service_body, k8s_core_client_mock
     ):
         k8s_core_client_mock.read_namespaced_secret.return_value = None
 
@@ -202,10 +243,15 @@ class TestServiceToTwingateResource:
             kopf.PermanentError,
             match="Kubernetes Secret object: gateway-tls is missing.",
         ):
-            service_to_twingate_resource(example_gateway_service_body, "default")
+            service_to_twingate_resource(
+                example_cluster_ip_gateway_service_body, "default"
+            )
 
     def test_kubernetes_resource_type_annotation_with_invalid_secret_type(
-        self, example_gateway_service_body, k8s_core_client_mock, k8s_tls_secret_mock
+        self,
+        example_cluster_ip_gateway_service_body,
+        k8s_core_client_mock,
+        k8s_tls_secret_mock,
     ):
         k8s_tls_secret_mock.type = "kubernetes.io/token"
         k8s_core_client_mock.read_namespaced_secret.return_value = k8s_tls_secret_mock
@@ -214,10 +260,15 @@ class TestServiceToTwingateResource:
             kopf.PermanentError,
             match="Kubernetes Secret object: gateway-tls type is invalid.",
         ):
-            service_to_twingate_resource(example_gateway_service_body, "default")
+            service_to_twingate_resource(
+                example_cluster_ip_gateway_service_body, "default"
+            )
 
     def test_kubernetes_resource_type_annotation_without_ca_cert(
-        self, example_gateway_service_body, k8s_core_client_mock, k8s_tls_secret_mock
+        self,
+        example_cluster_ip_gateway_service_body,
+        k8s_core_client_mock,
+        k8s_tls_secret_mock,
     ):
         k8s_tls_secret_mock.data = {}
         k8s_core_client_mock.read_namespaced_secret.return_value = k8s_tls_secret_mock
@@ -226,10 +277,15 @@ class TestServiceToTwingateResource:
             kopf.PermanentError,
             match="Kubernetes Secret object: gateway-tls is missing ca.crt.",
         ):
-            service_to_twingate_resource(example_gateway_service_body, "default")
+            service_to_twingate_resource(
+                example_cluster_ip_gateway_service_body, "default"
+            )
 
     def test_kubernetes_resource_type_annotation_with_invalid_ca_cert(
-        self, example_gateway_service_body, k8s_core_client_mock, k8s_tls_secret_mock
+        self,
+        example_cluster_ip_gateway_service_body,
+        k8s_core_client_mock,
+        k8s_tls_secret_mock,
     ):
         k8s_tls_secret_mock.data["ca.crt"] = (
             "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tIE1JSUZmakNDQTJhZ0F3SUJBZ0lVQk50IC0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0="
@@ -240,7 +296,75 @@ class TestServiceToTwingateResource:
             kopf.PermanentError,
             match="Kubernetes Secret object: gateway-tls ca.crt is invalid.",
         ):
-            service_to_twingate_resource(example_gateway_service_body, "default")
+            service_to_twingate_resource(
+                example_cluster_ip_gateway_service_body, "default"
+            )
+
+    def test_kubernetes_resource_with_load_balancer_service_type(
+        self,
+        example_load_balancer_gateway_service_body,
+        k8s_core_client_mock,
+        k8s_tls_secret_mock,
+    ):
+        tls_object_name = "gateway-tls"
+        namespace = "default"
+        k8s_core_client_mock.read_namespaced_secret.return_value = k8s_tls_secret_mock
+
+        result = service_to_twingate_resource(
+            example_load_balancer_gateway_service_body, namespace
+        )
+        k8s_core_client_mock.read_namespaced_secret.assert_called_once_with(
+            namespace=namespace, name=tls_object_name
+        )
+
+        assert result["spec"] == {
+            "name": "kubernetes-gateway-resource",
+            "address": "kubernetes.default.svc.cluster.local",
+            "alias": "gateway.default.svc.cluster.local",
+            "proxy": {
+                "address": "10.0.0.1",
+                "certificateAuthorityCert": BASE64_OF_VALID_CA_CERT,
+            },
+            "protocols": {
+                "allowIcmp": False,
+                "tcp": {
+                    "policy": "RESTRICTED",
+                    "ports": [{"start": 443, "end": 443}],
+                },
+                "udp": {
+                    "policy": "RESTRICTED",
+                    "ports": [],
+                },
+            },
+            "type": ResourceType.KUBERNETES,
+        }
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            {},
+            {"loadBalancer": {}},
+            {"loadBalancer": {"ingress": []}},
+            {"loadBalancer": {"ingress": [{"ip": "1.1.1.1"}]}},
+        ],
+    )
+    def test_retry_load_balancer_ip_is_not_ready(
+        self,
+        example_load_balancer_gateway_service_body,
+        kopf_handler_runner,
+        k8s_customobjects_client_mock,
+        status,
+    ):
+        # ruff: noqa: SLF001
+        example_load_balancer_gateway_service_body._status = status
+
+        with pytest.raises(
+            kopf.TemporaryError,
+            match="Kubernetes Service: kubernetes-gateway LoadBalancer IP is not ready.",
+        ):
+            service_to_twingate_resource(
+                example_load_balancer_gateway_service_body, "default"
+            )
 
 
 class TestK8sGetTwingateResource:


### PR DESCRIPTION
## Changes
- Create `proxy.address` with the ingress IP address when Service type is `LoadBalancer`
- Retry `twingate_service_create` handler when waiting to provision the IP address