### PR TITLE
feat: Support using `LoadBalancer` service hostname as proxy address

### DIFF
--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -71,18 +71,22 @@ ALLOWED_EXTRA_ANNOTATIONS: list[tuple[str, Callable]] = [
 TLS_OBJECT_ANNOTATION = "resource.twingate.com/tlsSecret"
 
 
-def validate_load_balancer_status(status: Status, service_name: str) -> None:
+def get_load_balancer_external_ip(status: Status, service_name: str) -> str:
     if not (ingress := status.get("loadBalancer", {}).get("ingress")):
         raise kopf.TemporaryError(
             f"Kubernetes Service: {service_name} LoadBalancer IP is not ready.",
             delay=30,
         )
 
-    if not ingress[0].get("ip"):
+    ip = ingress[0].get("ip")
+    hostname = ingress[0].get("hostname")
+    if not ip and not hostname:
         raise kopf.TemporaryError(
             f"Kubernetes Service: {service_name} LoadBalancer IP is not ready.",
             delay=30,
         )
+
+    return ip or hostname
 
 
 class ServiceType(StrEnum):
@@ -128,14 +132,11 @@ def service_to_twingate_resource(service_body: Body, namespace: str) -> dict:
                 f"Kubernetes Secret object: {tls_secret_name} is missing."
             )
 
-        if spec["type"] == ServiceType.LOAD_BALANCER:
-            validate_load_balancer_status(status, service_name)
-
         result["spec"] |= {
             "address": "kubernetes.default.svc.cluster.local",
             "proxy": {
                 "address": (
-                    status["loadBalancer"]["ingress"][0]["ip"]
+                    get_load_balancer_external_ip(status, service_name)
                     if spec["type"] == ServiceType.LOAD_BALANCER
                     else f"{service_name}.{namespace}.svc.cluster.local"
                 ),

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -301,19 +301,37 @@ class TestServiceToTwingateResource:
                 example_cluster_ip_gateway_service_body, "default"
             )
 
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            ({"loadBalancer": {"ingress": [{"ip": "1.2.3.4"}]}}, "1.2.3.4"),
+            (
+                {"loadBalancer": {"ingress": [{"hostname": "gateway.hostname.int"}]}},
+                "gateway.hostname.int",
+            ),
+        ],
+    )
     def test_kubernetes_resource_with_load_balancer_service_type(
         self,
         example_load_balancer_gateway_service_body,
         k8s_core_client_mock,
         k8s_tls_secret_mock,
+        status,
+        expected,
     ):
         tls_object_name = "gateway-tls"
         namespace = "default"
         k8s_core_client_mock.read_namespaced_secret.return_value = k8s_tls_secret_mock
 
-        result = service_to_twingate_resource(
-            example_load_balancer_gateway_service_body, namespace
-        )
+        with patch(
+            "kopf._cogs.structs.bodies.Body.status",
+            new_callable=PropertyMock,
+            return_value=status,
+        ):
+            result = service_to_twingate_resource(
+                example_load_balancer_gateway_service_body, namespace
+            )
+
         k8s_core_client_mock.read_namespaced_secret.assert_called_once_with(
             namespace=namespace, name=tls_object_name
         )
@@ -323,7 +341,7 @@ class TestServiceToTwingateResource:
             "address": "kubernetes.default.svc.cluster.local",
             "alias": "alias.int",
             "proxy": {
-                "address": "10.0.0.1",
+                "address": expected,
                 "certificateAuthorityCert": BASE64_OF_VALID_CA_CERT,
             },
             "protocols": {
@@ -347,6 +365,7 @@ class TestServiceToTwingateResource:
             {"loadBalancer": {}},
             {"loadBalancer": {"ingress": []}},
             {"loadBalancer": {"ingress": [{"ip": None}]}},
+            {"loadBalancer": {"ingress": [{"hostname": None}]}},
         ],
     )
     def test_kubernetes_resource_when_load_balancer_ip_is_not_ready(


### PR DESCRIPTION
## Changes
- Use `LoadBalancer` service hostname as proxy address if `ip` is not available

## Notes
Some Cloud providers' (E.g. AWS) `LoadBalancer` service does not have the `ip` field in the `status.loadBalancer.ingress[0]` object.