### PR TITLE
feat: Improve validation - ‘spec’ is always required

### DIFF
--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -12,6 +12,7 @@ spec:
         openAPIV3Schema:
           type: object
           description: "TwingateConnector represents a Connector in Twingate."
+          required: ["spec"]
           properties:
             spec:
               type: object

--- a/deploy/twingate-operator/crds/twingate.com.twingategroup.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingategroup.yaml
@@ -12,6 +12,7 @@ spec:
         openAPIV3Schema:
           type: object
           description: "TwingateGroup represents a Group in Twingate."
+          required: ["spec"]
           properties:
             spec:
               type: object

--- a/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
@@ -12,6 +12,7 @@ spec:
         openAPIV3Schema:
           type: object
           description: "TwingateResourceAccess represents a resource access policy in Twingate. It allows to configure an access between a Resource and a Principal which is either a Group or a ServiceAccount."
+          required: ["spec"]
           properties:
             spec:
               type: object

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -12,6 +12,7 @@ spec:
         openAPIV3Schema:
           type: object
           description: "TwingateResource represents a resource in Twingate."
+          required: ["spec"]
           properties:
             spec:
               type: object


### PR DESCRIPTION
We always assume `spec` is present in code. But the CRD allowd objects without `spec` which doesnt really make sense