### PR TITLE
chore: Github Action workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,8 @@ jobs:
           helm push twingate-operator-$CHART_VERSION.tgz oci://$REGISTRY/twingate/helmcharts
 
   release_prod:
+    permissions:
+      contents: read
     name: Release PROD
     runs-on: ubuntu-latest
     needs: [create_release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -88,8 +92,6 @@ jobs:
           helm push twingate-operator-$CHART_VERSION.tgz oci://$REGISTRY/twingate/helmcharts
 
   release_prod:
-    permissions:
-      contents: read
     name: Release PROD
     runs-on: ubuntu-latest
     needs: [create_release]

--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -1,5 +1,8 @@
 name: "PR Checks"
 on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -1,5 +1,6 @@
 name: "PR Checks"
 on: [pull_request]
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/vulnerability-monitor.yaml
+++ b/.github/workflows/vulnerability-monitor.yaml
@@ -1,4 +1,5 @@
 name: Vulnerability-Monitor
+
 permissions:
   contents: read
 

--- a/.github/workflows/vulnerability-monitor.yaml
+++ b/.github/workflows/vulnerability-monitor.yaml
@@ -1,4 +1,6 @@
 name: Vulnerability-Monitor
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Twingate/kubernetes-operator/security/code-scanning/9](https://github.com/Twingate/kubernetes-operator/security/code-scanning/9)

To fix the problem, add a `permissions` block to the `release_prod` job in `.github/workflows/release.yaml`. This block should specify the minimal permissions required for the job. As a starting point, set `contents: read`, which allows the job to read repository contents but not modify them. If the job later requires additional permissions (e.g., to create releases), these can be added as needed. The change should be made directly under the `release_prod` job definition, before the `name` or `runs-on` keys.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
