### PR TITLE
feat: Allow scoping Operator installation on specific namespaces

### DIFF
--- a/deploy/twingate-operator/templates/deployment.yaml
+++ b/deploy/twingate-operator/templates/deployment.yaml
@@ -45,7 +45,13 @@ spec:
           - kopf
           - run
           - ./main.py
-          - "-A"
+          {{- with .Values.twingateOperator.namespaces  }}
+          {{- range . }}
+          - "--namespace={{ . }}"
+          {{- end }}
+          {{- else }}
+          - "--all-namespaces"
+          {{- end }}
           - "--standalone"
           - "--liveness=http://0.0.0.0:8080/healthz"
           - "--log-format={{ $logFormat }}"

--- a/deploy/twingate-operator/tests/__snapshot__/default_values_test.yaml.snap
+++ b/deploy/twingate-operator/tests/__snapshot__/default_values_test.yaml.snap
@@ -111,7 +111,7 @@ should render:
                 - kopf
                 - run
                 - ./main.py
-                - -A
+                - --all-namespaces
                 - --standalone
                 - --liveness=http://0.0.0.0:8080/healthz
                 - --log-format=full

--- a/deploy/twingate-operator/tests/deployment_optional_values_test.yaml
+++ b/deploy/twingate-operator/tests/deployment_optional_values_test.yaml
@@ -41,17 +41,20 @@ tests:
     set:
       twingateOperator:
         namespaces:
-          - "foo"
-          - "bar"
+          - foo
+          - bar
     asserts:
-      - contains:
+      - equal:
           path: spec.template.spec.containers[0].command
-          content:
-            --namespace=foo
-      - contains:
-          path: spec.template.spec.containers[0].command
-          content:
-            --namespace=bar
+          value:
+            - kopf
+            - run
+            - ./main.py
+            - --namespace=foo
+            - --namespace=bar
+            - --standalone
+            - --liveness=http://0.0.0.0:8080/healthz
+            - --log-format=full
   - it: should use `imagePullSecrets`
     set:
       imagePullSecrets:

--- a/deploy/twingate-operator/tests/deployment_optional_values_test.yaml
+++ b/deploy/twingate-operator/tests/deployment_optional_values_test.yaml
@@ -37,6 +37,21 @@ tests:
           content:
             name: TWINGATE_DEFAULT_RESOURCE_TAGS
             value: '{"cluster":"test-cluster","owner":"eran"}'
+  - it: should use `namespaces`
+    set:
+      twingateOperator:
+        namespaces:
+          - "foo"
+          - "bar"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content:
+            --namespace=foo
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content:
+            --namespace=bar
   - it: should use `imagePullSecrets`
     set:
       imagePullSecrets:

--- a/deploy/twingate-operator/values.schema.json
+++ b/deploy/twingate-operator/values.schema.json
@@ -161,7 +161,7 @@
                     "description": "Array of namespaces to monitor by the operator",
                     "items": { "type": "string" },
                     "default": []
-        }
+                }
             },
             "examples": [{
               "apiKey": "sdlkwdlsknsldknsldkcnm",

--- a/deploy/twingate-operator/values.schema.json
+++ b/deploy/twingate-operator/values.schema.json
@@ -155,7 +155,13 @@
                     "additionalProperties": {
                         "type": "string"
                     }
-                }
+                },
+                "namespaces": {
+                    "type": "array",
+                    "description": "Array of namespaces to monitor by the operator",
+                    "items": { "type": "string" },
+                    "default": []
+        }
             },
             "examples": [{
               "apiKey": "sdlkwdlsknsldknsldkcnm",

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -2,9 +2,26 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Required: you have to specify `network` and
+# Twingate operator configurations
+#
+# **Required**: you have to specify `network` and
 #  - either `apiKey` or `existingAPIKeySecret`
 #  - either `remoteNetworkId`, `remoteNetworkName` or `existingRemoteNetworkIdSecret`
+#
+# **Restricting Operator to Specific Namespaces**
+# Use the `namespaces` property to restrict operator to monitor resources only in specific namespaces.
+# You can either:
+#  1. Specify a list of namespaces: ["foo-dev", "foo-stg"]
+#  2. Use globs to match multiple namespaces: ["*-dev", "*-stg"]
+#  3. Use negation to include all namespaces except those excluded: ["!kube-*"]
+#  4. Use multiple globs in one pattern: ["foo-*,!*-test"]
+#
+# Default value is an empty list (`[]`) which means operator will monitor or all namespaces.
+#
+# *Note:* Defining glob patterns as a separate array elements is different from defining
+# comma-separated patterns within a single element.
+# For example, `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
+# `namespaces: ["foo-*", "!*-test"]` will evaluate each glob pattern independently and combine the results.
 twingateOperator: {}
 #  apiKey: "<api key>"
 #  existingAPIKeySecret:
@@ -16,22 +33,13 @@ twingateOperator: {}
 #    name: my-secret
 #    key: TWINGATE_REMOTE_NETWORK_ID
 #  remoteNetworkName: "<remote network name>"
+#  namespaces: []
 #  logFormat: "plain|full|json"
 #  logVerbosity: "quiet|verbose|debug"
 #  defaultResourceTags:
 #    tag1: value_for_tag1
 #    tag2: value_for_tag2
 
-#  Restrict operator to monitor resources in specific namespaces. You should either:
-#  1. Specify a list of namespaces: ["foo-dev", "foo-stg"]
-#  2. Use globs to match multiple namespaces: ["*-dev", "*-stg"]
-#  3. Use negation to include all namespaces except those excluded: ["!kube-*"]
-#  4. Use multiple globs in one pattern: ["foo-*,!*-test"]
-#
-#  Note: Defining glob patterns as a separate array elements is different from defining comma-separated patterns within a single element.
-#  For example, `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
-#  `namespaces: ["foo-*", "!*-test"]` will evaluate each glob pattern independently and combine the results.
-namespaces: []
 
 # Twingate Kubernetes Access is currently in beta. Sign up for early access at https://www.twingate.com/product/kubernetes-access.
 kubernetes-access-gateway:

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -22,6 +22,22 @@ twingateOperator: {}
 #    tag1: value_for_tag1
 #    tag2: value_for_tag2
 
+## Restrict operator to monitor resources in specific namespaces. You should either:
+## 1. Specify a list of namespaces:
+## namespaces: ["foo-dev", "foo-stg"]
+## 2. Use globs to match multiple namespaces:
+## namespaces: ["*-dev", "*-stg"]
+## 3. Use negation to include all namespaces except those excluded:
+## namespaces: ["!*-test"]
+## 4. Use multiple globs can be used in one pattern:
+## namespaces: ["foo-*,!*-test"]
+
+## Caveat: Globs in separate array elements are evaluated independently, and the final list of namespaces is the union of all globs' results.
+## i.e., `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
+
+## For more information on using multiple globs, see: https://kopf.readthedocs.io/en/stable/scopes
+#  namespaces: []
+
 # Twingate Kubernetes Access is currently in beta. Sign up for early access at https://www.twingate.com/product/kubernetes-access.
 kubernetes-access-gateway:
   enabled: false

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -29,11 +29,12 @@ twingateOperator: {}
 ## namespaces: ["*-dev", "*-stg"]
 ## 3. Use negation to include all namespaces except those excluded:
 ## namespaces: ["!*-test"]
-## 4. Use multiple globs can be used in one pattern:
+## 4. Use multiple globs in one pattern:
 ## namespaces: ["foo-*,!*-test"]
 
-## Caveat: Globs in separate array elements are evaluated independently, and the final list of namespaces is the union of all globs' results.
-## i.e., `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
+## Note: Each glob pattern in separate array elements is evaluated independently, creating a union of results.
+## This differs from comma-separated patterns within a single element.
+## For example, `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
 
 ## For more information on using multiple globs, see: https://kopf.readthedocs.io/en/stable/scopes
 #  namespaces: []

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -22,21 +22,20 @@ twingateOperator: {}
 #    tag1: value_for_tag1
 #    tag2: value_for_tag2
 
-## Restrict operator to monitor resources in specific namespaces. You should either:
-## 1. Specify a list of namespaces:
-## namespaces: ["foo-dev", "foo-stg"]
-## 2. Use globs to match multiple namespaces:
-## namespaces: ["*-dev", "*-stg"]
-## 3. Use negation to include all namespaces except those excluded:
-## namespaces: ["!*-test"]
-## 4. Use multiple globs in one pattern:
-## namespaces: ["foo-*,!*-test"]
-## For more information on using multiple globs, see: https://kopf.readthedocs.io/en/stable/scopes
+#  Restrict operator to monitor resources in specific namespaces. You should either:
+#  1. Specify a list of namespaces:
+#  namespaces: ["foo-dev", "foo-stg"]
+#  2. Use globs to match multiple namespaces:
+#  namespaces: ["*-dev", "*-stg"]
+#  3. Use negation to include all namespaces except those excluded:
+#  namespaces: ["!*-test"]
+#  4. Use multiple globs in one pattern:
+#  namespaces: ["foo-*,!*-test"]
+#  For more information on using multiple globs, see: https://kopf.readthedocs.io/en/stable/scopes
 
-## Note: Defining glob patterns as a separate array elements is different from defining comma-separated patterns within a single element.
-## For example, `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
-## `namespaces: ["foo-*", "!*-test"]` will evaluate each glob pattern independently and combine the results.
-#  namespaces: ["default"]
+#  Note: Defining glob patterns as a separate array elements is different from defining comma-separated patterns within a single element.
+#  For example, `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
+#  `namespaces: ["foo-*", "!*-test"]` will evaluate each glob pattern independently and combine the results.
 
 # Twingate Kubernetes Access is currently in beta. Sign up for early access at https://www.twingate.com/product/kubernetes-access.
 kubernetes-access-gateway:

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -31,13 +31,12 @@ twingateOperator: {}
 ## namespaces: ["!*-test"]
 ## 4. Use multiple globs in one pattern:
 ## namespaces: ["foo-*,!*-test"]
-
-## Note: Each glob pattern in separate array elements is evaluated independently, creating a union of results.
-## This differs from comma-separated patterns within a single element.
-## For example, `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
-
 ## For more information on using multiple globs, see: https://kopf.readthedocs.io/en/stable/scopes
-#  namespaces: []
+
+## Note: Defining glob patterns as a separate array elements is different from defining comma-separated patterns within a single element.
+## For example, `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
+## `namespaces: ["foo-*", "!*-test"]` will evaluate each glob pattern independently and combine the results.
+#  namespaces: ["default"]
 
 # Twingate Kubernetes Access is currently in beta. Sign up for early access at https://www.twingate.com/product/kubernetes-access.
 kubernetes-access-gateway:

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -23,19 +23,15 @@ twingateOperator: {}
 #    tag2: value_for_tag2
 
 #  Restrict operator to monitor resources in specific namespaces. You should either:
-#  1. Specify a list of namespaces:
-#  namespaces: ["foo-dev", "foo-stg"]
-#  2. Use globs to match multiple namespaces:
-#  namespaces: ["*-dev", "*-stg"]
-#  3. Use negation to include all namespaces except those excluded:
-#  namespaces: ["!*-test"]
-#  4. Use multiple globs in one pattern:
-#  namespaces: ["foo-*,!*-test"]
-#  For more information on using multiple globs, see: https://kopf.readthedocs.io/en/stable/scopes
-
+#  1. Specify a list of namespaces: ["foo-dev", "foo-stg"]
+#  2. Use globs to match multiple namespaces: ["*-dev", "*-stg"]
+#  3. Use negation to include all namespaces except those excluded: ["!kube-*"]
+#  4. Use multiple globs in one pattern: ["foo-*,!*-test"]
+#
 #  Note: Defining glob patterns as a separate array elements is different from defining comma-separated patterns within a single element.
 #  For example, `namespaces: ["foo-*", "!*-test"]` is not the same as `namespaces: ["foo-*,!*-test"]`
 #  `namespaces: ["foo-*", "!*-test"]` will evaluate each glob pattern independently and combine the results.
+namespaces: []
 
 # Twingate Kubernetes Access is currently in beta. Sign up for early access at https://www.twingate.com/product/kubernetes-access.
 kubernetes-access-gateway:


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/719, https://github.com/Twingate/kubernetes-operator/issues/717

## Changes
- Allow scoping Operator installation on specific namespaces

## Notes
Currently, Operator will apply `twingate.com/kopf-managed` and `twingate.com/last-handled-configuration` annotations to all Kubernetes services & Twigate CRD across all namespaces. In some cases, we are not supposed to modify the k8s Service. Issue #717 is an example where we are not allowed to edit the `kube-system` namespace of the GKE autopilot cluster.
