### PR TITLE
fix: Add `securityContext` and `priorityClassName` to cleanup pod

### DIFF
--- a/deploy/twingate-operator/templates/pre-delete-cleanup.yaml
+++ b/deploy/twingate-operator/templates/pre-delete-cleanup.yaml
@@ -14,6 +14,11 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "twingate-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
         - name: cleanup
           securityContext:

--- a/deploy/twingate-operator/tests/__snapshot__/pre-delete-cleanup_test.yaml.snap
+++ b/deploy/twingate-operator/tests/__snapshot__/pre-delete-cleanup_test.yaml.snap
@@ -34,4 +34,7 @@ should enable pre-delete cleanup job:
                 runAsNonRoot: true
                 runAsUser: 1000
           restartPolicy: Never
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: RELEASE-NAME-twingate-operator


### PR DESCRIPTION
## Changes

Add `securityContext` and `priorityClassName` to the pod for `pre-delete-cleanup` job. 

## Notes

In k8s cluster that enforce pod security, the job wouldn't allow to run without `securityContext`.