### PR TITLE
fix: Fix `pre-delete-cleanup` job

### DIFF
--- a/deploy/twingate-operator/templates/pre-delete-cleanup.yaml
+++ b/deploy/twingate-operator/templates/pre-delete-cleanup.yaml
@@ -25,10 +25,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: rancher/kubectl:v1.34.0
           command:
-            - /bin/sh
-            - -c
-            - |
-              kubectl delete svc --cascade=foreground --timeout=30s --ignore-not-found -n {{ .Release.Namespace }} {{ $kubernetesAccessGatewayName }}
+            - kubectl
+            - delete
+            - svc
+            - --cascade=foreground
+            - --timeout=30s
+            - --ignore-not-found
+            - -n
+            - {{ .Release.Namespace }}
+            - {{ $kubernetesAccessGatewayName }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/twingate-operator/tests/__snapshot__/pre-delete-cleanup_test.yaml.snap
+++ b/deploy/twingate-operator/tests/__snapshot__/pre-delete-cleanup_test.yaml.snap
@@ -19,10 +19,15 @@ should enable pre-delete cleanup job:
         spec:
           containers:
             - command:
-                - /bin/sh
-                - -c
-                - |
-                  kubectl delete svc --cascade=foreground --timeout=30s --ignore-not-found -n NAMESPACE RELEASE-NAME-kubernetes-access-gateway
+                - kubectl
+                - delete
+                - svc
+                - --cascade=foreground
+                - --timeout=30s
+                - --ignore-not-found
+                - -n
+                - NAMESPACE
+                - RELEASE-NAME-kubernetes-access-gateway
               image: rancher/kubectl:v1.34.0
               name: cleanup
               securityContext:


### PR DESCRIPTION
## Changes

Unlike the `bitnami/kubectl` image (replaced in https://github.com/Twingate/kubernetes-operator/pull/768), `rancher/kubectl` image doesn't include a shell so we need to run `kubectl` directly. Currently, the `pre-delete-cleanup` job fails with the following error

```
Failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown
```