### PR TITLE
chore: Pin Helm version to latest v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: azure/setup-helm@v4
+        with:
+          version: 'v3.19.2'
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest
       - name: Build helm dependencies
@@ -221,7 +223,9 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - uses: azure/setup-helm@v4.3.0
+      - uses: azure/setup-helm@v4
+        with:
+          version: 'v3.19.2'
       - uses: chrisdickinson/setup-yq@latest
 
       - name: Set env vars


### PR DESCRIPTION
## Changes

Pin Helm version to latest v3 (3.19.2) because Helm Github action pull the Helm v4 and cause some breaking change like https://github.com/Azure/setup-helm/issues/241 ([failed build](https://github.com/Twingate/kubernetes-operator/actions/runs/19868290694/job/56936872813)).