### PR TITLE
feat: add status printer columns to TwingateResourceAccess CRD

### DIFF
--- a/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
@@ -88,6 +88,18 @@ spec:
               type: object
               x-kubernetes-preserve-unknown-fields: true
       additionalPrinterColumns:
+        - name: Success
+          type: boolean
+          description: "Whether the resource access was successfully created."
+          jsonPath: .status.twingate_resource_access_change.success
+        - name: Resource ID
+          type: string
+          description: "The ID of the Twingate resource."
+          jsonPath: .status.twingate_resource_access_change.resource_id
+        - name: Principal ID
+          type: string
+          description: "The ID of the principal (Group/ServiceAccount)."
+          jsonPath: .status.twingate_resource_access_change.principal_id
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
## Summary
- Add `additionalPrinterColumns` to the TwingateResourceAccess CRD so status is visible via `kubectl get`
- New columns: **Success**, **Resource ID**, **Principal ID** (sourced from `.status.twingate_resource_access_change`)

Resolves [OSS-117](https://linear.app/twingate/issue/OSS-117/add-status-columns-to-twingateresourceaccess-crd)

## Test plan
- [ ] Apply updated CRD to a cluster
- [ ] Create a TwingateResourceAccess object
- [ ] Verify `kubectl get tgra` shows Success, Resource ID, Principal ID, and Age columns
- [ ] Verify columns populate after the handler runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)