### PR TITLE
feat: Add protocol/port restriction annotation support

### DIFF
--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -10,6 +10,26 @@ from app.crds import ResourceType
 from app.utils import to_bool
 
 
+def parse_ports(value: str) -> list[dict]:
+    """Parse a comma-separated port string into port range dicts.
+
+    Supports single ports ("80") and ranges ("8080-8090").
+    Example: "80,443,8080-8090" -> [{"start": 80, "end": 80}, {"start": 443, "end": 443}, {"start": 8080, "end": 8090}]
+    """
+    ports = []
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start, end = part.split("-", 1)
+            ports.append({"start": int(start.strip()), "end": int(end.strip())})
+        else:
+            port = int(part)
+            ports.append({"start": port, "end": port})
+    return ports
+
+
 def k8s_get_twingate_resource(
     namespace: str, name: str, kapi: kubernetes.client.CustomObjectsApi | None = None
 ) -> dict | None:
@@ -119,6 +139,18 @@ def service_to_twingate_resource(service_body: Body, namespace: str) -> dict:
             protocols["tcp"]["ports"].append({"start": port, "end": port})
         elif port_obj["protocol"] == "UDP":
             protocols["udp"]["ports"].append({"start": port, "end": port})
+
+    # Allow annotation overrides for protocols
+    annotations = meta.annotations
+    for proto in ("tcp", "udp"):
+        if policy := annotations.get(f"resource.twingate.com/protocols.{proto}.policy"):
+            protocols[proto]["policy"] = policy
+        if ports_str := annotations.get(f"resource.twingate.com/protocols.{proto}.ports"):
+            protocols[proto]["ports"] = parse_ports(ports_str)
+            if protocols[proto]["policy"] != "ALLOW_ALL":
+                protocols[proto]["policy"] = "RESTRICTED"
+    if icmp := annotations.get("resource.twingate.com/protocols.allowIcmp"):
+        protocols["allowIcmp"] = to_bool(icmp)
 
     result["spec"]["protocols"] = protocols
 

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -304,6 +304,52 @@ class TestServiceToTwingateResource:
             )
 
 
+    def test_protocol_annotation_overrides_tcp_ports(self, example_service_body):
+        example_service_body.metadata["annotations"][
+            "resource.twingate.com/protocols.tcp.ports"
+        ] = "80"
+        result = service_to_twingate_resource(example_service_body, "default")
+        assert result["spec"]["protocols"]["tcp"] == {
+            "policy": "RESTRICTED",
+            "ports": [{"start": 80, "end": 80}],
+        }
+
+    def test_protocol_annotation_overrides_tcp_policy(self, example_service_body):
+        example_service_body.metadata["annotations"][
+            "resource.twingate.com/protocols.tcp.policy"
+        ] = "ALLOW_ALL"
+        result = service_to_twingate_resource(example_service_body, "default")
+        assert result["spec"]["protocols"]["tcp"]["policy"] == "ALLOW_ALL"
+
+    def test_protocol_annotation_overrides_udp_ports(self, example_service_body):
+        example_service_body.metadata["annotations"][
+            "resource.twingate.com/protocols.udp.ports"
+        ] = "53,5353"
+        result = service_to_twingate_resource(example_service_body, "default")
+        assert result["spec"]["protocols"]["udp"] == {
+            "policy": "RESTRICTED",
+            "ports": [{"start": 53, "end": 53}, {"start": 5353, "end": 5353}],
+        }
+
+    def test_protocol_annotation_port_ranges(self, example_service_body):
+        example_service_body.metadata["annotations"][
+            "resource.twingate.com/protocols.tcp.ports"
+        ] = "80,443,8080-8090"
+        result = service_to_twingate_resource(example_service_body, "default")
+        assert result["spec"]["protocols"]["tcp"]["ports"] == [
+            {"start": 80, "end": 80},
+            {"start": 443, "end": 443},
+            {"start": 8080, "end": 8090},
+        ]
+
+    def test_protocol_annotation_allow_icmp(self, example_service_body):
+        example_service_body.metadata["annotations"][
+            "resource.twingate.com/protocols.allowIcmp"
+        ] = "true"
+        result = service_to_twingate_resource(example_service_body, "default")
+        assert result["spec"]["protocols"]["allowIcmp"] is True
+
+
 class TestK8sGetTwingateResource:
     def test_handles_404_returns_none(self, k8s_customobjects_client_mock):
         k8s_customobjects_client_mock.get_namespaced_custom_object.side_effect = (


### PR DESCRIPTION

## Changes
- Add `parse_ports()` helper to parse comma-separated port strings with range support (e.g. `"80,443,8080-8090"`)
- After auto-deriving protocols from K8s service ports, check for annotation overrides:
  - `resource.twingate.com/protocols.tcp.policy` — `ALLOW_ALL` or `RESTRICTED`
  - `resource.twingate.com/protocols.tcp.ports` — e.g. `"80"`, `"80,443"`, `"80-90,443"`
  - `resource.twingate.com/protocols.udp.policy` / `ports` — same
  - `resource.twingate.com/protocols.allowIcmp` — `true` / `false`
- Add 5 unit tests covering all new annotation overrides

## Test plan
- [x] All 28 existing + new unit tests pass
- [ ] Deploy to dev and verify annotation-based port restrictions on a service

Generated with [Claude Code](https://claude.com/claude-code)