### PR TITLE
chore: Fix flaky connector flow integration test

### DIFF
--- a/app/handlers/handlers_connectors.py
+++ b/app/handlers/handlers_connectors.py
@@ -276,7 +276,7 @@ def twingate_connector_update(body, memo, logger, new, diff, status, namespace, 
 
     create_or_replace_deployment(body, namespace, crd, memo.twingate_settings.full_url)
 
-    return success(twingate_id=updated_connector.id)
+    return success(twingate_id=updated_connector.id, message="Update completed")
 
 
 @kopf.on.delete("twingateconnector")

--- a/app/handlers/tests/test_handlers_connector.py
+++ b/app/handlers/tests/test_handlers_connector.py
@@ -271,7 +271,12 @@ class TestTwingateConnectorUpdate:
         )
 
         mock_create_or_replace_deployment.assert_called_once()
-        assert run.result == {"success": True, "twingate_id": connector.id, "ts": ANY}
+        assert run.result == {
+            "success": True,
+            "twingate_id": connector.id,
+            "ts": ANY,
+            "message": "Update completed",
+        }
 
     def test_does_nothing_if_only_id_changed(
         self, get_connector_and_crd, kopf_handler_runner, mock_api_client

--- a/tests_integration/test_connector_flows.py
+++ b/tests_integration/test_connector_flows.py
@@ -1,5 +1,4 @@
 import functools
-import time
 from unittest.mock import ANY
 
 from tests_integration.utils import (
@@ -9,6 +8,7 @@ from tests_integration.utils import (
     kubectl_get,
     kubectl_patch,
     kubectl_wait_deployment_available,
+    kubectl_wait_object_handler_success,
     kubectl_wait_to_exist,
 )
 
@@ -67,7 +67,12 @@ def test_connector_flows(run_kopf, random_name_generator):
                 }
             },
         )
-        time.sleep(5)
+        kubectl_wait_object_handler_success(
+            "tc",
+            connector_name,
+            "twingate_connector_update/spec",
+            message="Update completed",
+        )
         deployment = wait_for_deployment()
         pod = deployment["spec"]["template"]
 
@@ -123,7 +128,12 @@ def test_connector_flows_image_change(run_kopf, random_name_generator):
         # Change image tag
         # kubectl patch tc/test-connector-image-local -p '{"spec": {"image": {"tag": "1.83.0"}}}' --type=merge
         kubectl_patch(f"tc/{connector_name}", {"spec": {"image": {"tag": "1.83.0"}}})
-        time.sleep(5)
+        kubectl_wait_object_handler_success(
+            "tc",
+            connector_name,
+            "twingate_connector_update/spec",
+            message="Update completed",
+        )
         wait_for_deployment()
 
         kubectl_delete_wait("tc", connector_name)

--- a/tests_integration/utils.py
+++ b/tests_integration/utils.py
@@ -160,12 +160,16 @@ def kubectl_wait_object_handler_success(
     resource_name: str,
     handler_name: str,
     *,
+    message: str | None = None,
     max_retries: int = 5,
 ):
     retry = 0
     obj = kubectl_wait_to_exist(resource_type, resource_name, max_retries=max_retries)
     while True:
-        if obj.get("status", {}).get(handler_name, {}).get("success"):
+        handler_status = obj.get("status", {}).get(handler_name, {})
+        if handler_status.get("success") and (
+            message is None or handler_status.get("message") == message
+        ):
             return obj
 
         retry += 1


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/940

## Changes
- Update tests to poll for a specific update message returned by the `twingate_connector_update` handler to ensure the connector deployment is updated.
- Update `twingate_connector_update` to write a new `"Update completed"` success message instead of keeping the old `"No update required"` message.

## Notes
The test is flaky because `time.sleep` is too short for the Connector deployment to reconcile. We should replace `time.sleep` with a better wait method. 

The reason we need to update the message is because: after the initial `kubectl_create`, the Kopf update handler may fire when `twingate_connector_create` patches the spec with the connector ID. That first update returns `"No update required"`. When we do `kubectl_patch`, the next update returns but the old `"No update required"` message is still there. The existing `kubectl_wait_object_handler_success` couldn't differentiate between these two handler invocations.