### PR TITLE
feat(chart): allow livenessProbe/readinessProbe tuning via values

### DIFF
--- a/deploy/twingate-operator/templates/deployment.yaml
+++ b/deploy/twingate-operator/templates/deployment.yaml
@@ -97,10 +97,16 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+          {{- with .Values.livenessProbe }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
+          {{- with .Values.readinessProbe }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deploy/twingate-operator/tests/deployment_optional_values_test.yaml
+++ b/deploy/twingate-operator/tests/deployment_optional_values_test.yaml
@@ -130,3 +130,47 @@ tests:
           content:
             name: FOO
             value: bar
+  - it: should use `livenessProbe` overrides
+    set:
+      livenessProbe:
+        timeoutSeconds: 5
+        periodSeconds: 30
+        failureThreshold: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+  - it: should use `readinessProbe` overrides
+    set:
+      readinessProbe:
+        timeoutSeconds: 5
+        periodSeconds: 30
+        failureThreshold: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 5

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -109,6 +109,21 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# Additional fields for the liveness probe, merged on top of the hardcoded
+# httpGet against /healthz on port 8080. Useful for tuning timeouts in busy
+# clusters where the kopf event loop may briefly saturate and starve the
+# /healthz endpoint (the default 1s timeoutSeconds is tight for such cases).
+# Example:
+#   livenessProbe:
+#     timeoutSeconds: 5
+#     periodSeconds: 30
+#     failureThreshold: 5
+livenessProbe: {}
+
+# Additional fields for the readiness probe. Same merge behavior and tuning
+# considerations as livenessProbe above.
+readinessProbe: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Summary

- Expose `livenessProbe` and `readinessProbe` as top-level Helm values
- Contents merge on top of the existing hardcoded `httpGet` endpoint
- Backward compatible: both default to `{}`, so rendered manifests are unchanged for existing users
- Adds helm-unittest coverage for both probes

## Why

The chart currently hardcodes both probes to:

```yaml
httpGet:
  path: /healthz
  port: 8080
```

with no way to override `timeoutSeconds`, `periodSeconds`, or `failureThreshold`. The resulting kubelet defaults (`timeout: 1s`, `period: 10s`, `failureThreshold: 3`) are tight for busy clusters where the kopf asyncio event loop can briefly saturate — for example, when many `TwingateConnector` CRs are being reconciled in a short window, or when the per-CR timer writes dominate the log output at INFO level.

In one real-world case we observed the `twingate-operator` pod SIGKILLed (Exit 137) **8 times in 12 hours** on a cluster running v0.29.0 with two `TwingateConnector` CRs. The container itself was running fine — the liveness probe was just missing its 1-second window under load. There's no way to loosen it today without forking the chart or post-rendering the manifest.

## Example usage after this change

```yaml
livenessProbe:
  timeoutSeconds: 5
  periodSeconds: 30
  failureThreshold: 5

readinessProbe:
  timeoutSeconds: 5
  periodSeconds: 30
```

Rendered output preserves the hardcoded endpoint and merges the overrides:

```yaml
livenessProbe:
  httpGet:
    path: /healthz
    port: 8080
  failureThreshold: 5
  periodSeconds: 30
  timeoutSeconds: 5
```

## Test plan

- [x] `helm template` renders correctly with and without the new values
- [x] Unit test added in `deployment_optional_values_test.yaml` asserting hardcoded httpGet is preserved and overrides land
- [x] Backward compatibility: default `{}` values produce identical manifests to previous behavior

## Related

We observed a separate issue in the operator itself where `twingate_connector_pod_reconciler` writes `TwingateConnector.status` every 5 seconds even when the reconcile result is a no-op (`message: "No update required"`), driving `metadata.generation` to six-figure values in a week or two and pressuring the asyncio event loop with log spam. That's a separate concern from this PR — this change simply lets operators loosen the liveness probe so the symptom doesn't manifest as a crash loop in the meantime. Happy to file a separate issue with evidence if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)