### PR TITLE
fix: retry TwingateResourceAccess quickly when referenced TwingateResource is missing (#904)

### DIFF
--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -74,7 +74,7 @@ def twingate_resource_access_change(body, spec, memo, logger, patch, status, **k
     if not resource_crd:
         err = f"Resource {access_crd.resource_ref_fullname} not found"
         kopf.warn(body, reason="ResourceNotFound", message=err)
-        return {"success": False, "error": err}
+        raise kopf.TemporaryError(err, delay=30)
 
     if not resource_crd.spec.id:
         raise kopf.TemporaryError("Resource not yet created, retrying...", delay=15)

--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -74,7 +74,7 @@ def twingate_resource_access_change(body, spec, memo, logger, patch, status, **k
     if not resource_crd:
         err = f"Resource {access_crd.resource_ref_fullname} not found"
         kopf.warn(body, reason="ResourceNotFound", message=err)
-        raise kopf.TemporaryError(err, delay=30)
+        raise kopf.TemporaryError(err, delay=15)
 
     if not resource_crd.spec.id:
         raise kopf.TemporaryError("Resource not yet created, retrying...", delay=15)

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -180,12 +180,17 @@ class TestResourceAccessChangeHandler:
         memo_mock = MagicMock()
         patch_mock = MagicMock()
 
-        with patch(
-            "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
-            return_value=None,
+        with (
+            patch(
+                "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
+                return_value=None,
+            ),
+            patch("kopf.warn") as kopf_warn_mock,
         ):
-            with patch("kopf.warn") as kopf_warn_mock:
-                result = twingate_resource_access_sync(
+            with pytest.raises(
+                kopf.TemporaryError, match=r"Resource default/invalid not found"
+            ):
+                twingate_resource_access_sync(
                     body="",
                     spec=resource_access_spec,
                     memo=memo_mock,
@@ -193,10 +198,6 @@ class TestResourceAccessChangeHandler:
                     patch=patch_mock,
                     status={},
                 )
-                assert result == {
-                    "success": False,
-                    "error": "Resource default/invalid not found",
-                }
 
             kopf_warn_mock.assert_called_once_with(
                 "",


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #904

## Changes

- Raise `kopf.TemporaryError` (delay=30s) instead of returning a failure dict when a `TwingateResourceAccess` references a `TwingateResource` that does not exist yet — Kopf will now retry the handler within ~30s instead of waiting up to 10 hours for the reconciliation timer.
- Preserve the existing `kopf.warn(reason="ResourceNotFound", ...)` so the K8s Event remains visible to `kubectl describe` and to ArgoCD.
- Update `test_create_invalid_ref` to assert the new raise behavior while still verifying the warning event is emitted.

## Notes

### Steps to reproduce (from the issue)

1. Apply a `TwingateResourceAccess` whose `resourceRef` points to a `TwingateResource` that hasn't been created yet (common with ArgoCD's arbitrary apply order).
2. Observe `Warning ResourceNotFound` in `kubectl describe`.
3. Apply the `TwingateResource`.
4. **Before this fix:** the access stays broken until the 10-hour `twingate_resource_access_sync` timer fires.
5. **After this fix:** the access reconciles within ~30 seconds.

### Root cause

In `app/handlers/handlers_resource_access.py`, the "resource not found" branch was returning a failure dict, which Kopf treats as a completed handler — no retry. The adjacent "resource exists but has no id yet" branch was already correctly raising `kopf.TemporaryError`. The fix aligns the two branches.

### Alternatives considered

- **Kopf indexers / event-driven reconcile of dependents** (watching `TwingateResource` create events to trigger immediate reconciliation of dependent `TwingateResourceAccess` resources). More responsive than polling, but a non-trivial architectural change. Deferred — 30-second retry resolves the user-visible pain.
- **Lowering the 10-hour `twingate_resource_access_sync` interval.** The long interval is intentional (see comment at `handlers_resource_access.py:115-117`) — tenants with many access CRDs can hit rate limits. Not changed.
- **Surfacing the failure as a CRD status condition for ArgoCD.** ArgoCD already sees the K8s Event from `kopf.warn` plus the existing status payload. Larger change with backwards-compat considerations — not needed for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)