### PR TITLE
chore: upgrade Python from 3.12.12 to 3.12.13

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-python 3.12.12
+python 3.12.13
 poetry 2.2.1


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #1025

## Changes

- Bump pinned Python runtime in `.tool-versions`: `3.12.12` → `3.12.13` (latest 3.12 patch release)

## Notes

`.tool-versions` is the single source of truth for the Python patch version:
- Local dev runtime (asdf) reads it directly
- The Docker image `PYTHON_VERSION` build arg is derived from the active runtime via the `Makefile`

CI workflows (`.github/workflows/*.yaml`) pin only the `3.12` minor and `pyproject.toml` uses a `>=3.11,<3.13` range, so no changes are required there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)