### PR TITLE
fix: mock shard host resolution in unit tests

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -13,15 +13,33 @@ def mocked_responses():
         yield rsps
 
 
+@pytest.fixture(autouse=True)
+def _mock_shard_resolution():
+    # Resolving the shard host makes a real (retried) HTTP request on every
+    # TwingateOperatorSettings construction. Make it a no-op in unit tests so
+    # they stay network-free. app/tests/test_settings.py overrides this with a
+    # no-op fixture to exercise the real resolver.
+    with patch(
+        "app.settings._resolve_shard_host", side_effect=lambda network, host: host
+    ):
+        yield
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _mock_settings():
     from app.settings import TwingateOperatorSettings
 
-    settings = TwingateOperatorSettings(
-        api_key="apikey",
-        network="network",
-        remote_network_id="UmVtb3RlTmV0d29yazoxMjMK",
-    )
+    # Module-scoped fixtures set up before the function-scoped
+    # _mock_shard_resolution above, so patch the resolver here too to keep
+    # construction network-free.
+    with patch(
+        "app.settings._resolve_shard_host", side_effect=lambda network, host: host
+    ):
+        settings = TwingateOperatorSettings(
+            api_key="apikey",
+            network="network",
+            remote_network_id="UmVtb3RlTmV0d29yazoxMjMK",
+        )
 
     with patch("app.crds.get_settings", return_value=settings):
         yield

--- a/app/tests/test_settings.py
+++ b/app/tests/test_settings.py
@@ -10,6 +10,13 @@ from app.settings import TwingateOperatorSettings, _resolve_shard_host, get_host
 
 
 @pytest.fixture(autouse=True)
+def _mock_shard_resolution():
+    # Override app/conftest.py's autouse mock: this module exercises the real
+    # shard resolver (_resolve_shard_host / get_host), so do not mock it here.
+    return
+
+
+@pytest.fixture(autouse=True)
 def _disable_retry_wait():
     original_wait = _resolve_shard_host.retry.wait
     _resolve_shard_host.retry.wait = wait_none()


### PR DESCRIPTION
## Related Tickets & Documents

- Regression from #998

## Changes

- Add an autouse fixture `_mock_shard_resolution` in `app/conftest.py` that patches `app.settings._resolve_shard_host` to a no-op passthrough, so unit tests don't make real network calls when constructing `TwingateOperatorSettings`.
- Patch the resolver inside the module-scoped `_mock_settings` construction as well (module-scoped fixtures set up before the function-scoped autouse, so it can't rely on it).
- Override the fixture with a no-op in `app/tests/test_settings.py` so its dedicated tests keep exercising the **real** `_resolve_shard_host` / `get_host`.

## Notes

For bug fixes:

- **Root cause:** #998 ("feat: Resolve shard URL at Operator startup") added `self.host = get_host(self.network, self.host)` to `TwingateOperatorSettings.__init__` (`app/settings.py:104`). `get_host` → `_resolve_shard_host` does a real `requests.head(...)` retried up to 3× with exponential backoff. `get_host` swallows all errors with a bare `except`, so the calls are silent — but the whole unit suite constructs settings (via the `_mock_settings`/`twingate_settings` fixtures and direct construction), so every run fired many real, retried network requests.
- **Reproduction:** run the unit suite on a machine where `*.twingate.com` HEAD requests are slow/blocked — the suite hangs in retry backoff. With the fix, `make test` runs **269 passed in ~1.2s** (previously minutes, dominated by network/backoff).
- `app/api/tests/conftest.py` and `app/handlers/tests/conftest.py` need no change — the function-scoped autouse covers `twingate_settings`, and the handlers conftest uses a `MagicMock` memo (never constructs settings).