### PR TITLE
fix: normalize CRD protocol port ranges to prevent false diffs

### DIFF
--- a/app/crds.py
+++ b/app/crds.py
@@ -102,6 +102,25 @@ class ResourceProtocol(BaseModel):
     policy: ProtocolPolicy = ProtocolPolicy.ALLOW_ALL
     ports: list[ProtocolRange] = Field(default_factory=list)
 
+    @field_validator("ports")
+    @classmethod
+    def normalize_ports(cls, ports: list[ProtocolRange]) -> list[ProtocolRange]:
+        if len(ports) <= 1:
+            return ports
+
+        sorted_ports = sorted(ports, key=lambda p: (p.start, p.end))
+        normalized_ports = [sorted_ports[0]]
+        for next_port in sorted_ports[1:]:
+            prev_port = normalized_ports[-1]
+            if next_port.start <= prev_port.end + 1:
+                normalized_ports[-1] = ProtocolRange(
+                    start=prev_port.start, end=max(prev_port.end, next_port.end)
+                )
+            else:
+                normalized_ports.append(next_port)
+
+        return normalized_ports
+
     @model_validator(mode="after")
     def check_policy_ports(self):
         if self.policy == ProtocolPolicy.ALLOW_ALL and self.ports:

--- a/app/tests/test_crds_resource.py
+++ b/app/tests/test_crds_resource.py
@@ -6,6 +6,9 @@ import pytest
 
 from app.api.tests.factories import BASE64_OF_VALID_CA_CERT, VALID_CA_CERT
 from app.crds import (
+    ProtocolPolicy,
+    ProtocolRange,
+    ResourceProtocol,
     ResourceProxy,
     ResourceSpec,
     ResourceType,
@@ -281,6 +284,50 @@ def test_resourceprotocol_ports_validation():
                 },
             },
         )
+
+
+class TestResourceProtocolNormalizePort:
+    def test_sorted_and_merged(self):
+        protocol = ResourceProtocol(
+            policy=ProtocolPolicy.RESTRICTED,
+            ports=[
+                ProtocolRange(start=443, end=443),
+                ProtocolRange(start=80, end=80),
+                ProtocolRange(start=81, end=81),
+            ],
+        )
+        assert protocol.ports == [
+            ProtocolRange(start=80, end=81),
+            ProtocolRange(start=443, end=443),
+        ]
+
+    def test_overlapping_ports_merged(self):
+        protocol = ResourceProtocol(
+            policy=ProtocolPolicy.RESTRICTED,
+            ports=[ProtocolRange(start=80, end=90), ProtocolRange(start=85, end=100)],
+        )
+        assert protocol.ports == [ProtocolRange(start=80, end=100)]
+
+    def test_disjoint_ports_stay_separate(self):
+        protocol = ResourceProtocol(
+            policy=ProtocolPolicy.RESTRICTED,
+            ports=[ProtocolRange(start=80, end=80), ProtocolRange(start=443, end=443)],
+        )
+        assert protocol.ports == [
+            ProtocolRange(start=80, end=80),
+            ProtocolRange(start=443, end=443),
+        ]
+
+    def test_single_port_unchanged(self):
+        protocol = ResourceProtocol(
+            policy=ProtocolPolicy.RESTRICTED,
+            ports=[ProtocolRange(start=8080, end=8080)],
+        )
+        assert protocol.ports == [ProtocolRange(start=8080, end=8080)]
+
+    def test_empty_ports_unchanged(self):
+        protocol = ResourceProtocol(policy=ProtocolPolicy.RESTRICTED, ports=[])
+        assert protocol.ports == []
 
 
 def test_resource_proxy_get_certificate_authority_cert_without_secret_ref():


### PR DESCRIPTION
## Related Tickets

Closes #1035

## Changes

- Add `field_validator` on `ResourceProtocol.ports` that merges overlapping/adjacent port ranges
- Add unit tests for normalization (adjacent, overlapping, unsorted, disjoint, single, empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)