### PR TITLE
chore: Add resource type as a display column

### DIFF
--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -172,6 +172,10 @@ spec:
           type: string
           description: "Name of the resource."
           jsonPath: .spec.name
+        - name: Type
+          type: string
+          description: "Type of the resource."
+          jsonPath: .spec.type
         - name: Address
           type: string
           description: "Address of the resource."


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/1037

## Changes

Add resource type as a display column

```
❯ kubectl get tgr                                                                                                                                                               
NAME                   ID    DISPLAY NAME      TYPE      ADDRESS                    ALIAS        AGE
my-twingate-resource         My K8S Resource   Network   my.default.cluster.local   mine.local   86s
```