### PR TITLE
feat: Support `requestHeaderRewrites` for `WebApp` resources

### DIFF
--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -331,7 +331,7 @@ class WebAppResource(BaseResource):
                 gateway { id }
                 downstream { port }
                 upstream { port }
-                requestHeaderRewrites { key value }
+                requestHeaderRewrites { name: key value }
             }
             """
         )
@@ -365,10 +365,10 @@ class WebAppResource(BaseResource):
         if self.upstream.port != crd_upstream_port:
             diff["upstream"] = Diff(remote=self.upstream.port, local=crd_upstream_port)
 
-        # Header rewrites are an unordered map of header name -> value, so compare
-        # them as dicts to avoid spurious diffs from ordering.
-        remote_headers = {h.key: h.value for h in self.request_header_rewrites}
-        crd_headers = crd.request_header_rewrites or {}
+        # Header rewrites are unordered, so compare them as name -> value dicts to
+        # avoid spurious diffs from ordering.
+        remote_headers = {h.name: h.value for h in self.request_header_rewrites}
+        crd_headers = {h.name: h.value for h in (crd.request_header_rewrites or [])}
         if remote_headers != crd_headers:
             diff["request_header_rewrites"] = Diff(
                 remote=remote_headers, local=crd_headers
@@ -382,9 +382,7 @@ class WebAppResource(BaseResource):
                 "type": ResourceType.WEB_APP,
                 "downstream": self.downstream,
                 "upstream": self.upstream,
-                "request_header_rewrites": {
-                    h.key: h.value for h in self.request_header_rewrites
-                },
+                "request_header_rewrites": self.request_header_rewrites,
             }
             | super().to_spec_dict()
             | overrides
@@ -415,7 +413,7 @@ QUERY_GET_RESOURCE = BaseResource.get_graphql_fragment() + """
                 gateway { id }
                 downstream { port }
                 upstream { port }
-                requestHeaderRewrites { key value }
+                requestHeaderRewrites { name: key value }
             }
         }
     }

--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -12,6 +12,7 @@ from app.api.exceptions import GraphQLMutationError
 from app.api.protocol import TwingateClientProtocol
 from app.crds import (
     ProtocolPolicy,
+    RequestHeaderRewrite,
     ResourceDownstream,
     ResourceProxy,
     ResourceSpec,
@@ -318,6 +319,7 @@ class WebAppResource(BaseResource):
     gateway: ResourceGateway | None = None
     downstream: ResourceDownstream
     upstream: ResourceUpstream
+    request_header_rewrites: list[RequestHeaderRewrite] = Field(default_factory=list)
 
     @staticmethod
     def get_graphql_fragment():
@@ -329,6 +331,7 @@ class WebAppResource(BaseResource):
                 gateway { id }
                 downstream { port }
                 upstream { port }
+                requestHeaderRewrites { key value }
             }
             """
         )
@@ -362,6 +365,15 @@ class WebAppResource(BaseResource):
         if self.upstream.port != crd_upstream_port:
             diff["upstream"] = Diff(remote=self.upstream.port, local=crd_upstream_port)
 
+        # Header rewrites are an unordered map of header name -> value, so compare
+        # them as dicts to avoid spurious diffs from ordering.
+        remote_headers = {h.key: h.value for h in self.request_header_rewrites}
+        crd_headers = crd.request_header_rewrites or {}
+        if remote_headers != crd_headers:
+            diff["request_header_rewrites"] = Diff(
+                remote=remote_headers, local=crd_headers
+            )
+
         return diff
 
     def to_spec(self, **overrides: Any) -> ResourceSpec:
@@ -370,6 +382,9 @@ class WebAppResource(BaseResource):
                 "type": ResourceType.WEB_APP,
                 "downstream": self.downstream,
                 "upstream": self.upstream,
+                "request_header_rewrites": {
+                    h.key: h.value for h in self.request_header_rewrites
+                },
             }
             | super().to_spec_dict()
             | overrides
@@ -400,6 +415,7 @@ QUERY_GET_RESOURCE = BaseResource.get_graphql_fragment() + """
                 gateway { id }
                 downstream { port }
                 upstream { port }
+                requestHeaderRewrites { key value }
             }
         }
     }
@@ -487,6 +503,7 @@ MUT_CREATE_WEB_APP_RESOURCE = _WEB_APP_RESOURCE_FRAGMENT + """
         $gatewayId: ID!
         $downstream: WebAppDownstreamInput!
         $upstream: WebAppUpstreamInput!
+        $requestHeaderRewrites: [KeyValueInputObject!]
     ) {
         webAppResourceCreate(
             name: $name
@@ -499,6 +516,7 @@ MUT_CREATE_WEB_APP_RESOURCE = _WEB_APP_RESOURCE_FRAGMENT + """
             gatewayId: $gatewayId
             downstream: $downstream
             upstream: $upstream
+            requestHeaderRewrites: $requestHeaderRewrites
         ) {
             ok
             error
@@ -599,6 +617,7 @@ MUT_UPDATE_WEB_APP_RESOURCE = _WEB_APP_RESOURCE_FRAGMENT + """
         $gatewayId: ID
         $downstream: WebAppDownstreamInput
         $upstream: WebAppUpstreamInput
+        $requestHeaderRewrites: [KeyValueInputObject!]
     ) {
         webAppResourceUpdate(
             id: $id,
@@ -612,6 +631,7 @@ MUT_UPDATE_WEB_APP_RESOURCE = _WEB_APP_RESOURCE_FRAGMENT + """
             gatewayId: $gatewayId
             downstream: $downstream
             upstream: $upstream
+            requestHeaderRewrites: $requestHeaderRewrites
         ) {
             ok
             error
@@ -756,6 +776,7 @@ class TwingateResourceAPIs:
         gateway_id: str,
         downstream: dict[str, Any],
         upstream: dict[str, Any],
+        request_header_rewrites: list[dict[str, str]],
     ) -> WebAppResource:
         result = self.execute_mutation(
             "webAppResourceCreate",
@@ -772,6 +793,7 @@ class TwingateResourceAPIs:
                     "gatewayId": gateway_id,
                     "downstream": downstream,
                     "upstream": upstream,
+                    "requestHeaderRewrites": request_header_rewrites,
                 },
             ),
         )
@@ -877,6 +899,7 @@ class TwingateResourceAPIs:
         gateway_id: str,
         downstream: dict[str, Any],
         upstream: dict[str, Any],
+        request_header_rewrites: list[dict[str, str]],
     ) -> WebAppResource | None:
         result = self.execute_mutation(
             "webAppResourceUpdate",
@@ -894,6 +917,7 @@ class TwingateResourceAPIs:
                     "gatewayId": gateway_id,
                     "downstream": downstream,
                     "upstream": upstream,
+                    "requestHeaderRewrites": request_header_rewrites,
                 },
             ),
         )

--- a/app/api/tests/test_client_resources.py
+++ b/app/api/tests/test_client_resources.py
@@ -324,13 +324,16 @@ class TestWebAppResourceModel:
         resource = web_app_resource_factory(
             gateway=ResourceGateway(id="gw-1"),
             request_header_rewrites=[
-                RequestHeaderRewrite(key="X-A", value="1"),
-                RequestHeaderRewrite(key="X-B", value="2"),
+                RequestHeaderRewrite(name="X-A", value="1"),
+                RequestHeaderRewrite(name="X-B", value="2"),
             ],
         )
         crd = resource.to_spec(
             gateway_ref={"name": "my-gateway"},
-            request_header_rewrites={"X-B": "2", "X-A": "1"},
+            request_header_rewrites=[
+                {"name": "X-B", "value": "2"},
+                {"name": "X-A", "value": "1"},
+            ],
         )
 
         with patch(
@@ -341,11 +344,11 @@ class TestWebAppResourceModel:
     def test_get_spec_diff_for_header_rewrite_drift(self, web_app_resource_factory):
         resource = web_app_resource_factory(
             gateway=ResourceGateway(id="gw-1"),
-            request_header_rewrites=[RequestHeaderRewrite(key="X-A", value="1")],
+            request_header_rewrites=[RequestHeaderRewrite(name="X-A", value="1")],
         )
         crd = resource.to_spec(
             gateway_ref={"name": "my-gateway"},
-            request_header_rewrites={"X-A": "2"},
+            request_header_rewrites=[{"name": "X-A", "value": "2"}],
         )
 
         with patch(

--- a/app/api/tests/test_client_resources.py
+++ b/app/api/tests/test_client_resources.py
@@ -17,7 +17,13 @@ from app.api.client_resources import (
     ResourceProtocols,
 )
 from app.api.tests.factories import VALID_CA_CERT, VALID_CA_CERT_1
-from app.crds import ProtocolPolicy, ResourceProxy, ResourceSpec, ResourceType
+from app.crds import (
+    ProtocolPolicy,
+    RequestHeaderRewrite,
+    ResourceProxy,
+    ResourceSpec,
+    ResourceType,
+)
 
 
 @pytest.fixture
@@ -312,6 +318,45 @@ class TestWebAppResourceModel:
         ):
             assert resource.get_spec_diff(crd) == {}
 
+    def test_get_spec_diff_ignores_header_rewrite_ordering(
+        self, web_app_resource_factory
+    ):
+        resource = web_app_resource_factory(
+            gateway=ResourceGateway(id="gw-1"),
+            request_header_rewrites=[
+                RequestHeaderRewrite(key="X-A", value="1"),
+                RequestHeaderRewrite(key="X-B", value="2"),
+            ],
+        )
+        crd = resource.to_spec(
+            gateway_ref={"name": "my-gateway"},
+            request_header_rewrites={"X-B": "2", "X-A": "1"},
+        )
+
+        with patch(
+            "app.api.client_resources.resolve_ref_to_twingate_id", return_value="gw-1"
+        ):
+            assert resource.get_spec_diff(crd) == {}
+
+    def test_get_spec_diff_for_header_rewrite_drift(self, web_app_resource_factory):
+        resource = web_app_resource_factory(
+            gateway=ResourceGateway(id="gw-1"),
+            request_header_rewrites=[RequestHeaderRewrite(key="X-A", value="1")],
+        )
+        crd = resource.to_spec(
+            gateway_ref={"name": "my-gateway"},
+            request_header_rewrites={"X-A": "2"},
+        )
+
+        with patch(
+            "app.api.client_resources.resolve_ref_to_twingate_id", return_value="gw-1"
+        ):
+            assert resource.get_spec_diff(crd) == {
+                "request_header_rewrites": Diff(
+                    remote={"X-A": "1"}, local={"X-A": "2"}
+                ),
+            }
+
 
 class TestResourceFactory:
     def test_name_is_used_for_address(self, base_resource_factory):
@@ -492,6 +537,7 @@ class TestTwingateResourceAPIs:
                                 "gateway_ref",
                                 "downstream",
                                 "upstream",
+                                "request_header_rewrites",
                             ],
                             by_alias=True,
                         )
@@ -542,6 +588,7 @@ class TestTwingateResourceAPIs:
                                 "gateway_ref",
                                 "downstream",
                                 "upstream",
+                                "request_header_rewrites",
                             ],
                             by_alias=True,
                         )
@@ -591,6 +638,7 @@ class TestTwingateResourceAPIs:
                                 "gateway_ref",
                                 "downstream",
                                 "upstream",
+                                "request_header_rewrites",
                             },
                             by_alias=True,
                         )
@@ -711,6 +759,7 @@ class TestTwingateResourceAPIs:
                                 "gateway_ref",
                                 "downstream",
                                 "upstream",
+                                "request_header_rewrites",
                             ],
                             by_alias=True,
                         )
@@ -758,6 +807,7 @@ class TestTwingateResourceAPIs:
                                 "gateway_ref",
                                 "downstream",
                                 "upstream",
+                                "request_header_rewrites",
                             },
                             by_alias=True,
                         )

--- a/app/crds.py
+++ b/app/crds.py
@@ -214,7 +214,7 @@ class RequestHeaderRewrite(BaseModel):
         frozen=True, populate_by_name=True, alias_generator=to_camel
     )
 
-    key: str
+    name: str
     value: str
 
 
@@ -250,9 +250,8 @@ class ResourceSpec(BaseModel):
     # (downstream = client-facing, upstream = backend).
     downstream: ResourceDownstream | None = None
     upstream: ResourceUpstream | None = None
-    # (WebApp only) HTTP headers to rewrite on requests to the upstream
-    # (header name -> value).
-    request_header_rewrites: dict[str, str] | None = None
+    # (WebApp only) HTTP headers to rewrite on requests to the upstream.
+    request_header_rewrites: list[RequestHeaderRewrite] | None = None
 
     def __is_wildcard(self):
         return "*" in self.address or "?" in self.address
@@ -374,8 +373,8 @@ class ResourceSpec(BaseModel):
                     "downstream": downstream.model_dump(by_alias=True),
                     "upstream": upstream.model_dump(by_alias=True),
                     "request_header_rewrites": [
-                        {"key": key, "value": value}
-                        for key, value in (self.request_header_rewrites or {}).items()
+                        {"key": h.name, "value": h.value}
+                        for h in (self.request_header_rewrites or [])
                     ],
                 }
 

--- a/app/crds.py
+++ b/app/crds.py
@@ -209,6 +209,15 @@ class ResourceUpstream(BaseModel):
     port: Port
 
 
+class RequestHeaderRewrite(BaseModel):
+    model_config = ConfigDict(
+        frozen=True, populate_by_name=True, alias_generator=to_camel
+    )
+
+    key: str
+    value: str
+
+
 class ResourceType(StrEnum):
     NETWORK = "Network"
     KUBERNETES = "Kubernetes"
@@ -237,10 +246,13 @@ class ResourceSpec(BaseModel):
     proxy: ResourceProxy | None = None
     # Reference to a TwingateGateway, the replacement for `proxy`.
     gateway_ref: _KubernetesObjectRef | None = None
-    # Downstream/upstream connection configuration relative to the gateway
-    # (downstream = client-facing, upstream = backend); currently only used by WebApp.
+    # (WebApp only) connection configuration relative to the gateway
+    # (downstream = client-facing, upstream = backend).
     downstream: ResourceDownstream | None = None
     upstream: ResourceUpstream | None = None
+    # (WebApp only) HTTP headers to rewrite on requests to the upstream
+    # (header name -> value).
+    request_header_rewrites: dict[str, str] | None = None
 
     def __is_wildcard(self):
         return "*" in self.address or "?" in self.address
@@ -258,7 +270,11 @@ class ResourceSpec(BaseModel):
     def check_proxy_and_gateway_ref(self):
         has_proxy = self.proxy is not None
         has_gateway_ref = self.gateway_ref is not None
-        has_endpoints = self.downstream is not None or self.upstream is not None
+        has_endpoints = (
+            self.downstream is not None
+            or self.upstream is not None
+            or self.request_header_rewrites is not None
+        )
 
         match self.type:
             case ResourceType.NETWORK:
@@ -268,7 +284,8 @@ class ResourceSpec(BaseModel):
                     )
                 if has_endpoints:
                     raise ValueError(
-                        "Network resources cannot set `downstream` or `upstream`."
+                        "Network resources cannot set `downstream`, `upstream`, or "
+                        "`requestHeaderRewrites`."
                     )
             case ResourceType.KUBERNETES:
                 if has_proxy == has_gateway_ref:
@@ -278,7 +295,8 @@ class ResourceSpec(BaseModel):
                     )
                 if has_endpoints:
                     raise ValueError(
-                        "Kubernetes resources cannot set `downstream` or `upstream`."
+                        "Kubernetes resources cannot set `downstream`, `upstream`, or "
+                        "`requestHeaderRewrites`."
                     )
             case ResourceType.WEB_APP:
                 if has_proxy:
@@ -304,6 +322,7 @@ class ResourceSpec(BaseModel):
             "gateway_ref",
             "downstream",
             "upstream",
+            "request_header_rewrites",
         }
         graphql_args = {
             **self.model_dump(exclude=exclude | default_exclude_fields),
@@ -354,6 +373,10 @@ class ResourceSpec(BaseModel):
                     ),
                     "downstream": downstream.model_dump(by_alias=True),
                     "upstream": upstream.model_dump(by_alias=True),
+                    "request_header_rewrites": [
+                        {"key": key, "value": value}
+                        for key, value in (self.request_header_rewrites or {}).items()
+                    ],
                 }
 
         return graphql_args

--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -154,18 +154,20 @@ def _web_app_spec(service_body: Body, namespace: str) -> dict:
     }
 
     if rewrites := meta.annotations.get(REQUEST_HEADER_REWRITES_ANNOTATION):
+        invalid_msg = (
+            f"{REQUEST_HEADER_REWRITES_ANNOTATION} annotation must be a JSON "
+            "object mapping header names to string values."
+        )
         try:
             parsed = json.loads(rewrites)
         except json.JSONDecodeError as ex:
-            raise kopf.PermanentError(
-                f"{REQUEST_HEADER_REWRITES_ANNOTATION} annotation must be a JSON "
-                "object mapping header names to values."
-            ) from ex
-        if not isinstance(parsed, dict):
-            raise kopf.PermanentError(
-                f"{REQUEST_HEADER_REWRITES_ANNOTATION} annotation must be a JSON "
-                "object mapping header names to values."
-            )
+            raise kopf.PermanentError(invalid_msg) from ex
+
+        if not isinstance(parsed, dict) or not all(
+            isinstance(value, str) for value in parsed.values()
+        ):
+            raise kopf.PermanentError(invalid_msg)
+
         web_app_spec["requestHeaderRewrites"] = parsed
 
     return web_app_spec

--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Callable
 from enum import StrEnum
 
@@ -37,6 +38,7 @@ GATEWAY_NAME_ANNOTATION = "resource.twingate.com/gatewayName"
 GATEWAY_NAMESPACE_ANNOTATION = "resource.twingate.com/gatewayNamespace"
 DOWNSTREAM_PORT_ANNOTATION = "resource.twingate.com/downstreamPort"
 UPSTREAM_PORT_ANNOTATION = "resource.twingate.com/upstreamPort"
+REQUEST_HEADER_REWRITES_ANNOTATION = "resource.twingate.com/requestHeaderRewrites"
 
 
 def get_load_balancer_address(status: Status, service_name: str) -> str:
@@ -142,7 +144,7 @@ def _web_app_spec(service_body: Body, namespace: str) -> dict:
             tcp_ports, UPSTREAM_PORT_ANNOTATION, service_name
         )
 
-    return {
+    web_app_spec: dict = {
         "gatewayRef": {
             "name": gateway_name,
             "namespace": meta.annotations.get(GATEWAY_NAMESPACE_ANNOTATION, namespace),
@@ -150,6 +152,23 @@ def _web_app_spec(service_body: Body, namespace: str) -> dict:
         "downstream": {"port": downstream},
         "upstream": {"port": upstream},
     }
+
+    if rewrites := meta.annotations.get(REQUEST_HEADER_REWRITES_ANNOTATION):
+        try:
+            parsed = json.loads(rewrites)
+        except json.JSONDecodeError as ex:
+            raise kopf.PermanentError(
+                f"{REQUEST_HEADER_REWRITES_ANNOTATION} annotation must be a JSON "
+                "object mapping header names to values."
+            ) from ex
+        if not isinstance(parsed, dict):
+            raise kopf.PermanentError(
+                f"{REQUEST_HEADER_REWRITES_ANNOTATION} annotation must be a JSON "
+                "object mapping header names to values."
+            )
+        web_app_spec["requestHeaderRewrites"] = parsed
+
+    return web_app_spec
 
 
 def _kubernetes_spec(service_body: Body, namespace: str) -> dict:

--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -168,7 +168,9 @@ def _web_app_spec(service_body: Body, namespace: str) -> dict:
         ):
             raise kopf.PermanentError(invalid_msg)
 
-        web_app_spec["requestHeaderRewrites"] = parsed
+        web_app_spec["requestHeaderRewrites"] = [
+            {"name": name, "value": value} for name, value in parsed.items()
+        ]
 
     return web_app_spec
 

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -490,6 +490,51 @@ class TestServiceToTwingateResource:
         ):
             service_to_twingate_resource(example_webapp_service_body, "default")
 
+    def test_webapp_resource_request_header_rewrites(self, example_webapp_service_body):
+        example_webapp_service_body.metadata["annotations"][
+            "resource.twingate.com/requestHeaderRewrites"
+        ] = '{"Host": "example.com", "X-Foo": "bar"}'
+
+        result = service_to_twingate_resource(example_webapp_service_body, "default")
+
+        assert result["spec"]["requestHeaderRewrites"] == {
+            "Host": "example.com",
+            "X-Foo": "bar",
+        }
+
+    def test_webapp_resource_without_request_header_rewrites(
+        self, example_webapp_service_body
+    ):
+        result = service_to_twingate_resource(example_webapp_service_body, "default")
+
+        assert "requestHeaderRewrites" not in result["spec"]
+
+    def test_webapp_resource_invalid_request_header_rewrites(
+        self, example_webapp_service_body
+    ):
+        example_webapp_service_body.metadata["annotations"][
+            "resource.twingate.com/requestHeaderRewrites"
+        ] = "not-json"
+
+        with pytest.raises(
+            kopf.PermanentError,
+            match=r"resource.twingate.com/requestHeaderRewrites annotation must be a JSON",
+        ):
+            service_to_twingate_resource(example_webapp_service_body, "default")
+
+    def test_webapp_resource_non_object_request_header_rewrites(
+        self, example_webapp_service_body
+    ):
+        example_webapp_service_body.metadata["annotations"][
+            "resource.twingate.com/requestHeaderRewrites"
+        ] = '[{"key": "Host", "value": "example.com"}]'
+
+        with pytest.raises(
+            kopf.PermanentError,
+            match=r"resource.twingate.com/requestHeaderRewrites annotation must be a JSON",
+        ):
+            service_to_twingate_resource(example_webapp_service_body, "default")
+
 
 class TestK8sGetTwingateResource:
     def test_handles_404_returns_none(self, k8s_customobjects_client_mock):

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -497,10 +497,10 @@ class TestServiceToTwingateResource:
 
         result = service_to_twingate_resource(example_webapp_service_body, "default")
 
-        assert result["spec"]["requestHeaderRewrites"] == {
-            "Host": "example.com",
-            "X-Foo": "bar",
-        }
+        assert result["spec"]["requestHeaderRewrites"] == [
+            {"name": "Host", "value": "example.com"},
+            {"name": "X-Foo", "value": "bar"},
+        ]
 
     def test_webapp_resource_without_request_header_rewrites(
         self, example_webapp_service_body

--- a/app/tests/test_crds_resource.py
+++ b/app/tests/test_crds_resource.py
@@ -573,7 +573,7 @@ def test_network_resource_rejects_request_header_rewrites():
         ResourceSpec(
             name="My Network Resource",
             address="network.default.cluster.local",
-            request_header_rewrites={"X-Foo": "bar"},
+            request_header_rewrites=[{"name": "X-Foo", "value": "bar"}],
         )
 
 
@@ -585,7 +585,7 @@ def test_web_app_resource_spec_to_graphql_arguments():
         gateway_ref=_KubernetesObjectRef(name="my-gateway", namespace="twingate"),
         downstream=ResourceDownstream(port=80),
         upstream=ResourceUpstream(port=8080),
-        request_header_rewrites={"X-Forwarded-Host": "web-app.int"},
+        request_header_rewrites=[{"name": "X-Forwarded-Host", "value": "web-app.int"}],
     )
 
     with patch(

--- a/app/tests/test_crds_resource.py
+++ b/app/tests/test_crds_resource.py
@@ -557,14 +557,23 @@ def test_web_app_resource_requires_downstream_and_upstream():
 
 
 def test_network_resource_rejects_downstream_and_upstream():
-    with pytest.raises(
-        ValueError, match="Network resources cannot set `downstream` or `upstream`"
-    ):
+    with pytest.raises(ValueError, match="Network resources cannot set `downstream`"):
         ResourceSpec(
             name="My Network Resource",
             address="network.default.cluster.local",
             downstream=ResourceDownstream(port=80),
             upstream=ResourceUpstream(port=8080),
+        )
+
+
+def test_network_resource_rejects_request_header_rewrites():
+    with pytest.raises(
+        ValueError, match=r"Network resources cannot set .*`requestHeaderRewrites`"
+    ):
+        ResourceSpec(
+            name="My Network Resource",
+            address="network.default.cluster.local",
+            request_header_rewrites={"X-Foo": "bar"},
         )
 
 
@@ -576,6 +585,7 @@ def test_web_app_resource_spec_to_graphql_arguments():
         gateway_ref=_KubernetesObjectRef(name="my-gateway", namespace="twingate"),
         downstream=ResourceDownstream(port=80),
         upstream=ResourceUpstream(port=8080),
+        request_header_rewrites={"X-Forwarded-Host": "web-app.int"},
     )
 
     with patch(
@@ -589,10 +599,29 @@ def test_web_app_resource_spec_to_graphql_arguments():
     assert graphql_arguments["gateway_id"] == "R2F0ZXdheTo5Nwo="
     assert graphql_arguments["downstream"] == {"port": 80}
     assert graphql_arguments["upstream"] == {"port": 8080}
+    assert graphql_arguments["request_header_rewrites"] == [
+        {"key": "X-Forwarded-Host", "value": "web-app.int"}
+    ]
     assert "proxy_address" not in graphql_arguments
     assert "gateway_ref" not in graphql_arguments
     assert "type" not in graphql_arguments
     assert "protocols" not in graphql_arguments
+
+
+def test_web_app_resource_spec_to_graphql_arguments_without_header_rewrites():
+    resource_spec = ResourceSpec(
+        name="My WebApp Resource",
+        address="webapp.default.cluster.local",
+        type=ResourceType.WEB_APP,
+        gateway_ref=_KubernetesObjectRef(name="my-gateway"),
+        downstream=ResourceDownstream(port=80),
+        upstream=ResourceUpstream(port=8080),
+    )
+
+    with patch("app.crds.resolve_ref_to_twingate_id", return_value="gw-1"):
+        graphql_arguments = resource_spec.to_graphql_arguments(labels={})
+
+    assert graphql_arguments["request_header_rewrites"] == []
 
 
 def test_resource_spec_to_graphql_arguments_when_sync_labels_disabled(

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -200,6 +200,8 @@ spec:
                 requestHeaderRewrites:
                   type: array
                   description: "HTTP headers to rewrite on requests to the upstream of a WebApp Resource."
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys: ["name"]
                   items:
                     type: object
                     required: ["name", "value"]

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -24,6 +24,8 @@ spec:
                   message: "Kubernetes Resource requires exactly one of proxy (deprecated) or gatewayRef; WebApp Resource requires gatewayRef and no proxy; Network Resource allows neither"
                 - rule: (self.type == "WebApp" && has(self.downstream) && has(self.upstream)) || (self.type != "WebApp" && !has(self.downstream) && !has(self.upstream))
                   message: "WebApp Resource requires downstream and upstream; other Resource types allow neither"
+                - rule: '!has(self.requestHeaderRewrites) || self.type == "WebApp"'
+                  message: "requestHeaderRewrites can only be set for WebApp Resources"
                 - rule: (self.isBrowserShortcutEnabled && self.type == "Network") || (self.isBrowserShortcutEnabled == false)
                   message: "isBrowserShortcutEnabled can only be set to true for Network Resources"
               required: ["name", "address"]
@@ -195,6 +197,11 @@ spec:
                       minimum: 1
                       maximum: 65535
                       description: "The upstream port."
+                requestHeaderRewrites:
+                  type: object
+                  description: "HTTP headers to rewrite on requests to the upstream of a WebApp Resource. Maps header name to value."
+                  additionalProperties:
+                    type: string
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -198,10 +198,18 @@ spec:
                       maximum: 65535
                       description: "The upstream port."
                 requestHeaderRewrites:
-                  type: object
-                  description: "HTTP headers to rewrite on requests to the upstream of a WebApp Resource. Maps header name to value."
-                  additionalProperties:
-                    type: string
+                  type: array
+                  description: "HTTP headers to rewrite on requests to the upstream of a WebApp Resource."
+                  items:
+                    type: object
+                    required: ["name", "value"]
+                    properties:
+                      name:
+                        type: string
+                        description: "The header name."
+                      value:
+                        type: string
+                        description: "The header value."
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/examples/resource.yaml
+++ b/examples/resource.yaml
@@ -36,3 +36,5 @@ spec:
     port: 80
   upstream:
     port: 8080
+  requestHeaderRewrites:
+    Authorization: "Bearer {{ twingate.jwt }}"

--- a/examples/resource.yaml
+++ b/examples/resource.yaml
@@ -37,4 +37,5 @@ spec:
   upstream:
     port: 8080
   requestHeaderRewrites:
-    Authorization: "Bearer {{ twingate.jwt }}"
+    - name: Authorization
+      value: "Bearer {{ twingate.jwt }}"

--- a/examples/resource.yaml
+++ b/examples/resource.yaml
@@ -38,4 +38,4 @@ spec:
     port: 8080
   requestHeaderRewrites:
     - name: Authorization
-      value: "Bearer {{ twingate.jwt }}"
+      value: "Bearer {{ jwt }}"

--- a/examples/service.yaml
+++ b/examples/service.yaml
@@ -35,6 +35,8 @@ metadata:
     # Optional. Upstream (target) port. Defaults to the Service's port when it
     # exposes exactly one; required if the Service exposes multiple ports.
     # resource.twingate.com/upstreamPort: "8080"
+    # Optional. HTTP headers to rewrite on requests to the upstream (WebApp only).
+    # resource.twingate.com/requestHeaderRewrites: '{"Host":"example.com"}'
     resource.twingate.com/alias: "webapp.internal"
 spec:
   selector:

--- a/tests_integration/test_crds_resource.py
+++ b/tests_integration/test_crds_resource.py
@@ -660,6 +660,53 @@ def test_web_app_resource_rejects_out_of_range_port(unique_resource_name):
     assert "spec.downstream.port" in stderr
 
 
+def test_web_app_resource_with_request_header_rewrites_accepted(unique_resource_name):
+    result = kubectl_create(
+        f"""
+        apiVersion: twingate.com/v1beta
+        kind: TwingateResource
+        metadata:
+          name: {unique_resource_name}
+        spec:
+          name: My WebApp Resource
+          address: "webapp.default.svc.cluster.local"
+          type: WebApp
+          gatewayRef:
+            name: my-gateway
+          downstream:
+            port: 80
+          upstream:
+            port: 8080
+          requestHeaderRewrites:
+            X-Forwarded-Host: web-app.int
+        """
+    )
+    assert result.returncode == 0
+    kubectl_delete("tgr", unique_resource_name)
+
+
+def test_non_web_app_resource_cannot_have_request_header_rewrites(
+    unique_resource_name,
+):
+    with pytest.raises(subprocess.CalledProcessError) as ex:
+        kubectl_create(
+            f"""
+            apiVersion: twingate.com/v1beta
+            kind: TwingateResource
+            metadata:
+              name: {unique_resource_name}
+            spec:
+              name: My Network Resource
+              address: "network.default.svc.cluster.local"
+              requestHeaderRewrites:
+                X-Forwarded-Host: web-app.int
+            """
+        )
+
+    stderr = ex.value.stderr.decode()
+    assert "requestHeaderRewrites can only be set for WebApp Resources" in stderr
+
+
 def test_kubernetes_resource_cannot_have_browser_shortcut(unique_resource_name):
     with pytest.raises(subprocess.CalledProcessError) as ex:
         kubectl_create(

--- a/tests_integration/test_crds_resource.py
+++ b/tests_integration/test_crds_resource.py
@@ -715,6 +715,38 @@ def test_web_app_resource_request_header_rewrite_requires_name_and_value(
     assert "value" in stderr
 
 
+def test_web_app_resource_rejects_duplicate_request_header_rewrite_names(
+    unique_resource_name,
+):
+    with pytest.raises(subprocess.CalledProcessError) as ex:
+        kubectl_create(
+            f"""
+            apiVersion: twingate.com/v1beta
+            kind: TwingateResource
+            metadata:
+              name: {unique_resource_name}
+            spec:
+              name: My WebApp Resource
+              address: "webapp.default.svc.cluster.local"
+              type: WebApp
+              gatewayRef:
+                name: my-gateway
+              downstream:
+                port: 80
+              upstream:
+                port: 8080
+              requestHeaderRewrites:
+                - name: X-Forwarded-Host
+                  value: web-app.int
+                - name: X-Forwarded-Host
+                  value: other.int
+            """
+        )
+
+    stderr = ex.value.stderr.decode()
+    assert "duplicate" in stderr.lower()
+
+
 def test_non_web_app_resource_cannot_have_request_header_rewrites(
     unique_resource_name,
 ):

--- a/tests_integration/test_crds_resource.py
+++ b/tests_integration/test_crds_resource.py
@@ -678,11 +678,41 @@ def test_web_app_resource_with_request_header_rewrites_accepted(unique_resource_
           upstream:
             port: 8080
           requestHeaderRewrites:
-            X-Forwarded-Host: web-app.int
+            - name: X-Forwarded-Host
+              value: web-app.int
         """
     )
     assert result.returncode == 0
     kubectl_delete("tgr", unique_resource_name)
+
+
+def test_web_app_resource_request_header_rewrite_requires_name_and_value(
+    unique_resource_name,
+):
+    with pytest.raises(subprocess.CalledProcessError) as ex:
+        kubectl_create(
+            f"""
+            apiVersion: twingate.com/v1beta
+            kind: TwingateResource
+            metadata:
+              name: {unique_resource_name}
+            spec:
+              name: My WebApp Resource
+              address: "webapp.default.svc.cluster.local"
+              type: WebApp
+              gatewayRef:
+                name: my-gateway
+              downstream:
+                port: 80
+              upstream:
+                port: 8080
+              requestHeaderRewrites:
+                - name: X-Forwarded-Host
+            """
+        )
+
+    stderr = ex.value.stderr.decode()
+    assert "value" in stderr
 
 
 def test_non_web_app_resource_cannot_have_request_header_rewrites(
@@ -699,7 +729,8 @@ def test_non_web_app_resource_cannot_have_request_header_rewrites(
               name: My Network Resource
               address: "network.default.svc.cluster.local"
               requestHeaderRewrites:
-                X-Forwarded-Host: web-app.int
+                - name: X-Forwarded-Host
+                  value: web-app.int
             """
         )
 

--- a/tests_integration/test_service_flows.py
+++ b/tests_integration/test_service_flows.py
@@ -587,7 +587,9 @@ def test_service_flows_with_webapp_resource(run_kopf, random_name_generator):
                 "gatewayRef": {"name": gw_name, "namespace": "default"},
                 "downstream": {"port": 80},
                 "upstream": {"port": 8080},
-                "requestHeaderRewrites": {"X-Forwarded-Host": "web-app.int"},
+                "requestHeaderRewrites": [
+                    {"name": "X-Forwarded-Host", "value": "web-app.int"}
+                ],
                 "id": ANY,
                 "isBrowserShortcutEnabled": False,
                 "isVisible": True,

--- a/tests_integration/test_service_flows.py
+++ b/tests_integration/test_service_flows.py
@@ -546,7 +546,7 @@ def test_service_flows_with_webapp_resource(run_kopf, random_name_generator):
             resource.twingate.com/gatewayName: "{gw_name}"
             resource.twingate.com/downstreamPort: "80"
             resource.twingate.com/alias: "webapp.internal"
-            resource.twingate.com/requestHeaderRewrites: '{{"X-Forwarded-Host": "web-app.int"}}'
+            resource.twingate.com/requestHeaderRewrites: '{{"X-Forwarded-Host": "web-app.int", "Authorization": "Bearer {{{{ jwt }}}}"}}'
         spec:
           selector:
             app.kubernetes.io/name: MyApp
@@ -588,7 +588,8 @@ def test_service_flows_with_webapp_resource(run_kopf, random_name_generator):
                 "downstream": {"port": 80},
                 "upstream": {"port": 8080},
                 "requestHeaderRewrites": [
-                    {"name": "X-Forwarded-Host", "value": "web-app.int"}
+                    {"name": "X-Forwarded-Host", "value": "web-app.int"},
+                    {"name": "Authorization", "value": "Bearer {{ jwt }}"},
                 ],
                 "id": ANY,
                 "isBrowserShortcutEnabled": False,

--- a/tests_integration/test_service_flows.py
+++ b/tests_integration/test_service_flows.py
@@ -546,6 +546,7 @@ def test_service_flows_with_webapp_resource(run_kopf, random_name_generator):
             resource.twingate.com/gatewayName: "{gw_name}"
             resource.twingate.com/downstreamPort: "80"
             resource.twingate.com/alias: "webapp.internal"
+            resource.twingate.com/requestHeaderRewrites: '{{"X-Forwarded-Host": "web-app.int"}}'
         spec:
           selector:
             app.kubernetes.io/name: MyApp
@@ -586,6 +587,7 @@ def test_service_flows_with_webapp_resource(run_kopf, random_name_generator):
                 "gatewayRef": {"name": gw_name, "namespace": "default"},
                 "downstream": {"port": 80},
                 "upstream": {"port": 8080},
+                "requestHeaderRewrites": {"X-Forwarded-Host": "web-app.int"},
                 "id": ANY,
                 "isBrowserShortcutEnabled": False,
                 "isVisible": True,


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/1037

## Changes

- Add `requestHeaderRewrites` support for WebApp Resources (rewrite HTTP headers on requests to the upstream)
- `TwingateResource` CRD: new `spec.requestHeaderRewrites` map (header name → value), WebApp-only
  - CEL rule rejects it on non-WebApp types
- Service annotation `resource.twingate.com/requestHeaderRewrites` (JSON object) → maps to the CRD field
- Wire the field through WebApp create/update mutations and the get query
- Examples updated (`examples/resource.yaml`, `examples/service.yaml`)

## Notes

- Exposed as an unordered map, but the API models header rewrites as an ordered list, so header reordering is intentionally not treated as a change.
- Invalid annotation input (malformed JSON, or valid JSON that isn't an object) fails loudly rather than being silently ignored.
