### PR TITLE
feat: add remoteNetworkId to TwingateResource and TwingateConnector CRDs

### DIFF
--- a/app/tests/test_crds_connector.py
+++ b/app/tests/test_crds_connector.py
@@ -105,6 +105,20 @@ def test_deserialization_imagepolicy(sample_connector_object_imagepolicy):
     assert crd.spec.pod_labels == {"my-label": "my-value"}
 
 
+def test_remote_network_id_defaults_to_settings(sample_connector_object_image):
+    crd = TwingateConnectorCRD(**sample_connector_object_image)
+    # `_mock_settings` (app/conftest.py) sets the operator-wide default.
+    assert crd.spec.remote_network_id == "UmVtb3RlTmV0d29yazoxMjMK"
+
+
+def test_remote_network_id_override(sample_connector_object_image):
+    sample_connector_object_image["spec"]["remoteNetworkId"] = (
+        "UmVtb3RlTmV0d29yazo5OTkK"
+    )
+    crd = TwingateConnectorCRD(**sample_connector_object_image)
+    assert crd.spec.remote_network_id == "UmVtb3RlTmV0d29yazo5OTkK"
+
+
 def test_deserialization_imagepolicy_fails_on_invalid_version_specifier(
     sample_connector_object_imagepolicy,
 ):

--- a/app/tests/test_crds_resource.py
+++ b/app/tests/test_crds_resource.py
@@ -204,6 +204,21 @@ def test_deserialization(sample_network_resource_object):
     assert crd.metadata.uid == "c560d138-a93a-4463-8b44-d7717851a265"
 
 
+def test_remote_network_id_defaults_to_settings(sample_network_resource_object):
+    sample_network_resource_object["spec"].pop("remoteNetworkId", None)
+    crd = TwingateResourceCRD(**sample_network_resource_object)
+    # `_mock_settings` (app/conftest.py) sets the operator-wide default.
+    assert crd.spec.remote_network_id == "UmVtb3RlTmV0d29yazoxMjMK"
+
+
+def test_remote_network_id_override(sample_network_resource_object):
+    sample_network_resource_object["spec"]["remoteNetworkId"] = (
+        "UmVtb3RlTmV0d29yazo5OTkK"
+    )
+    crd = TwingateResourceCRD(**sample_network_resource_object)
+    assert crd.spec.remote_network_id == "UmVtb3RlTmV0d29yazo5OTkK"
+
+
 def test_is_browser_shortcut_enabled_disallowed_on_wildcard_resource():
     with pytest.raises(ValueError, match=r"isBrowserShortcutEnabled"):
         TwingateResourceCRD(

--- a/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
@@ -20,6 +20,8 @@ spec:
               x-kubernetes-validations:
                 - rule: (!has(oldSelf.id) || self.id == oldSelf.id)
                   message: "id is immutable once set"
+                - rule: (!has(oldSelf.remoteNetworkId) || self.remoteNetworkId == oldSelf.remoteNetworkId)
+                  message: "remoteNetworkId is immutable once set"
                 - rule: (has(self.image) && !has(self.imagePolicy)) || (!has(self.image) && has(self.imagePolicy)) || (!has(self.image) && !has(self.imagePolicy))
                   message: "Can define either `image` or `imagePolicy`, not both."
               properties:
@@ -30,6 +32,10 @@ spec:
                   type: string
                   maxLength: 30
                   description: "Name of the Connector (optional, if not specified Twingate will give a random name)"
+                remoteNetworkId:
+                  type: string
+                  pattern: "^[-A-Za-z0-9+/]*={0,3}$"
+                  description: "ID of the Twingate Remote Network this Connector belongs to. Overrides the operator-wide default (TWINGATE_REMOTE_NETWORK_ID). Immutable once set."
                 logLevel:
                   type: integer
                   default: 3

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -28,6 +28,8 @@ spec:
                   message: "requestHeaderRewrites can only be set for WebApp Resources"
                 - rule: (self.isBrowserShortcutEnabled && self.type == "Network") || (self.isBrowserShortcutEnabled == false)
                   message: "isBrowserShortcutEnabled can only be set to true for Network Resources"
+                - rule: (!has(oldSelf.remoteNetworkId) || self.remoteNetworkId == oldSelf.remoteNetworkId)
+                  message: "remoteNetworkId is immutable once set"
               required: ["name", "address"]
               properties:
                 id:
@@ -47,6 +49,10 @@ spec:
                   type: boolean
                   default: false
                   description: "isBrowserShortcutEnabled specifies whether the resource will display a browser shortcut in the Twingate client."
+                remoteNetworkId:
+                  type: string
+                  pattern: "^[-A-Za-z0-9+/]*={0,3}$"
+                  description: "ID of the Twingate Remote Network this Resource belongs to. Overrides the operator-wide default (TWINGATE_REMOTE_NETWORK_ID). Immutable once set."
                 securityPolicyId:
                   type: string
                   nullable: true

--- a/tests_integration/test_crds_connector.py
+++ b/tests_integration/test_crds_connector.py
@@ -3,7 +3,12 @@ from unittest.mock import ANY
 
 import pytest
 
-from tests_integration.utils import kubectl_create, kubectl_delete, kubectl_get
+from tests_integration.utils import (
+    kubectl_apply,
+    kubectl_create,
+    kubectl_delete,
+    kubectl_get,
+)
 
 
 @pytest.fixture
@@ -336,3 +341,73 @@ class TestConnectorCRD:
 
         stderr = ex.value.stderr.decode()
         assert "Google provider requires specifying repository." in stderr
+
+    def test_remote_network_id(self, unique_connector_name):
+        result = kubectl_create(
+            f"""
+            apiVersion: twingate.com/v1beta
+            kind: TwingateConnector
+            metadata:
+                name: {unique_connector_name}
+            spec:
+                name: {unique_connector_name}
+                remoteNetworkId: "UmVtb3RlTmV0d29yazoxMjMK"
+            """
+        )
+
+        assert result.returncode == 0
+
+        data = kubectl_get("tc", unique_connector_name)
+        assert data["spec"]["remoteNetworkId"] == "UmVtb3RlTmV0d29yazoxMjMK"
+
+        kubectl_delete("tc", unique_connector_name)
+
+    def test_remote_network_id_invalid_pattern(self, unique_connector_name):
+        with pytest.raises(subprocess.CalledProcessError) as ex:
+            kubectl_create(
+                f"""
+                apiVersion: twingate.com/v1beta
+                kind: TwingateConnector
+                metadata:
+                    name: {unique_connector_name}
+                spec:
+                    name: {unique_connector_name}
+                    remoteNetworkId: "not valid!"
+                """
+            )
+
+        stderr = ex.value.stderr.decode()
+        assert "spec.remoteNetworkId in body should match" in stderr
+
+    def test_remote_network_id_is_immutable(self, unique_connector_name):
+        result = kubectl_create(
+            f"""
+            apiVersion: twingate.com/v1beta
+            kind: TwingateConnector
+            metadata:
+                name: {unique_connector_name}
+            spec:
+                name: {unique_connector_name}
+                remoteNetworkId: "UmVtb3RlTmV0d29yazoxMjMK"
+            """
+        )
+        assert result.returncode == 0
+
+        try:
+            with pytest.raises(subprocess.CalledProcessError) as ex:
+                kubectl_apply(
+                    f"""
+                    apiVersion: twingate.com/v1beta
+                    kind: TwingateConnector
+                    metadata:
+                        name: {unique_connector_name}
+                    spec:
+                        name: {unique_connector_name}
+                        remoteNetworkId: "UmVtb3RlTmV0d29yazo0NTYK"
+                    """
+                )
+
+            stderr = ex.value.stderr.decode()
+            assert "remoteNetworkId is immutable once set" in stderr
+        finally:
+            kubectl_delete("tc", unique_connector_name)

--- a/tests_integration/test_crds_resource.py
+++ b/tests_integration/test_crds_resource.py
@@ -6,6 +6,7 @@ from tests_integration.utils import (
     kubectl_apply,
     kubectl_create,
     kubectl_delete,
+    kubectl_get,
 )
 
 
@@ -870,3 +871,80 @@ def test_kubernetes_resource_proxy_object_missing_either_ca_cert_string_or_secre
         '"spec.proxy" must validate one and only one schema (oneOf). Found none valid'
         in stderr
     )
+
+
+def test_remote_network_id(unique_resource_name):
+    result = kubectl_create(
+        f"""
+        apiVersion: twingate.com/v1beta
+        kind: TwingateResource
+        metadata:
+          name: {unique_resource_name}
+        spec:
+          name: My K8S Resource
+          address: "foo.default.cluster.local"
+          remoteNetworkId: "UmVtb3RlTmV0d29yazoxMjMK"
+        """
+    )
+
+    assert result.returncode == 0
+
+    data = kubectl_get("tgr", unique_resource_name)
+    assert data["spec"]["remoteNetworkId"] == "UmVtb3RlTmV0d29yazoxMjMK"
+
+    kubectl_delete("tgr", unique_resource_name)
+
+
+def test_remote_network_id_invalid_pattern(unique_resource_name):
+    with pytest.raises(subprocess.CalledProcessError) as ex:
+        kubectl_create(
+            f"""
+            apiVersion: twingate.com/v1beta
+            kind: TwingateResource
+            metadata:
+              name: {unique_resource_name}
+            spec:
+              name: My K8S Resource
+              address: "foo.default.cluster.local"
+              remoteNetworkId: "not valid!"
+            """
+        )
+
+    stderr = ex.value.stderr.decode()
+    assert "spec.remoteNetworkId in body should match" in stderr
+
+
+def test_remote_network_id_is_immutable(unique_resource_name):
+    result = kubectl_create(
+        f"""
+        apiVersion: twingate.com/v1beta
+        kind: TwingateResource
+        metadata:
+          name: {unique_resource_name}
+        spec:
+          name: My K8S Resource
+          address: "foo.default.cluster.local"
+          remoteNetworkId: "UmVtb3RlTmV0d29yazoxMjMK"
+        """
+    )
+    assert result.returncode == 0
+
+    try:
+        with pytest.raises(subprocess.CalledProcessError) as ex:
+            kubectl_apply(
+                f"""
+                apiVersion: twingate.com/v1beta
+                kind: TwingateResource
+                metadata:
+                  name: {unique_resource_name}
+                spec:
+                  name: My K8S Resource
+                  address: "foo.default.cluster.local"
+                  remoteNetworkId: "UmVtb3RlTmV0d29yazo0NTYK"
+                """
+            )
+
+        stderr = ex.value.stderr.decode()
+        assert "remoteNetworkId is immutable once set" in stderr
+    finally:
+        kubectl_delete("tgr", unique_resource_name)


### PR DESCRIPTION
## Related Tickets & Documents

- Issue:

## Changes

- Add `remoteNetworkId` to the **TwingateResource** and **TwingateConnector** CRD spec schemas (string, validated with the same base64 GlobalID `pattern` as `securityPolicyId`)
- Make the field **immutable once set** via an optional-immutable CEL guard: `(!has(oldSelf.remoteNetworkId) || self.remoteNetworkId == oldSelf.remoteNetworkId)` — the same shape the connector CRD already uses for `id`
- Add integration tests (happy path, invalid-pattern rejection, immutability rejection) to `tests_integration/test_crds_connector.py` and `tests_integration/test_crds_resource.py`
- Add unit tests covering the settings-default fallback and the explicit per-object override

## Notes

The Pydantic models already supported this field — `ResourceSpec.remote_network_id` and `ConnectorSpec.remote_network_id` (both defaulting to `get_settings().remote_network_id`, i.e. the operator-wide `TWINGATE_REMOTE_NETWORK_ID`). But because neither CRD schema declared `remoteNetworkId` and the `spec` objects don't set `x-kubernetes-preserve-unknown-fields`, `kubectl` dropped/rejected the field, so it was unreachable in practice. This PR only touches the CRD YAMLs + tests; no Python model changes were needed.

This unlocks running a single operator across **multiple** remote networks by overriding the operator-wide default per Resource/Connector.

Design choices:
- **No CRD-level `default`** — the runtime default must stay the Pydantic default-factory (settings). A YAML default would bake the operator default into stored objects and, combined with immutability, permanently lock them.
- **Not `nullable`** — the Python type is `str` (unlike `securityPolicyId` which is `str | None`), so a literal `null` should be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)