### PR TITLE
test: Use unique CA names in integration tests

### DIFF
--- a/tests_integration/test_gateway_flows.py
+++ b/tests_integration/test_gateway_flows.py
@@ -44,7 +44,7 @@ def test_gateway_flows(run_kopf, random_name_generator):
         metadata:
           name: {ca_name}
         spec:
-          name: My CA
+          name: {ca_name}
           secretRef:
             name: {secret_name}
     """

--- a/tests_integration/test_service_flows.py
+++ b/tests_integration/test_service_flows.py
@@ -321,7 +321,7 @@ def test_service_flows_with_webapp_resource(run_kopf, random_name_generator):
         metadata:
           name: {ca_name}
         spec:
-          name: My CA
+          name: {ca_name}
           secretRef:
             name: {secret_name}
     """


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #1037

## Changes

- Use the random per-test name for `TwingateCertificateAuthority.spec.name` instead of the hardcoded `My CA`
  - `test_gateway_flows`
  - `test_service_flows_with_webapp_resource`

## Notes

Root cause: backend CA names are unique per tenant, so the hardcoded `My CA` collides between concurrent test runs against the same tenant. [Sample failed build](https://github.com/Twingate/kubernetes-operator/actions/runs/30313964251/job/90135444970?pr=1104).
