### PR TITLE
feat: add `remoteNetworkId` to TwingateGateway CRD

### DIFF
--- a/app/crds.py
+++ b/app/crds.py
@@ -396,6 +396,9 @@ class GatewaySpec(BaseModel):
     )
 
     id: str | None = None
+    remote_network_id: str = Field(
+        default_factory=lambda: get_settings().remote_network_id
+    )
     # Reference to the Service fronting the Gateway. The operator resolves the
     # host from the Service and combines it with `serviceRef.port` into the
     # `status.address` the Twingate Client connects to.

--- a/app/handlers/handlers_gateways.py
+++ b/app/handlers/handlers_gateways.py
@@ -43,7 +43,7 @@ def _reconcile_gateway(body, spec, logger, memo, patch, status=None):
         logger.info("Updating gateway %s", gw_spec.id)
         client.gateway_update(
             gateway_id=gw_spec.id,
-            remote_network_id=settings.remote_network_id,
+            remote_network_id=gw_spec.remote_network_id,
             address=address,
             x509_ca_id=x509_ca_id,
         )
@@ -58,7 +58,7 @@ def _reconcile_gateway(body, spec, logger, memo, patch, status=None):
         logger.info("Creating gateway")
     gateway = client.gateway_create(
         address=address,
-        remote_network_id=settings.remote_network_id,
+        remote_network_id=gw_spec.remote_network_id,
         x509_ca_id=x509_ca_id,
     )
     patch.spec["id"] = gateway.id

--- a/app/handlers/tests/test_handlers_gateways.py
+++ b/app/handlers/tests/test_handlers_gateways.py
@@ -76,7 +76,7 @@ class TestGatewayCreateUpdateHandler:
         assert result == {"success": True, "twingate_id": gateway.id, "ts": ANY}
         mock_api_client.gateway_create.assert_called_once_with(
             address="gateway.default.svc.cluster.local:443",
-            remote_network_id=ANY,
+            remote_network_id="UmVtb3RlTmV0d29yazoxMjMK",
             x509_ca_id="ca-backend-id",
         )
         mock_api_client.gateway_update.assert_not_called()
@@ -85,6 +85,21 @@ class TestGatewayCreateUpdateHandler:
             "address": "gateway.default.svc.cluster.local:443",
             "x509CaId": "ca-backend-id",
         }
+
+    def test_create_with_remote_network_id_override(
+        self, kopf_info_mock, mock_api_client, call_create_update
+    ):
+        mock_api_client.gateway_create.return_value = Gateway(
+            id="new-gateway-id", address="addr"
+        )
+
+        call_create_update(_spec() | {"remoteNetworkId": "UmVtb3RlTmV0d29yazo5OTkK"})
+
+        mock_api_client.gateway_create.assert_called_once_with(
+            address="gateway.default.svc.cluster.local:443",
+            remote_network_id="UmVtb3RlTmV0d29yazo5OTkK",
+            x509_ca_id="ca-backend-id",
+        )
 
     def test_update_existing(self, mock_api_client, call_create_update):
         mock_api_client.get_gateway.return_value = Gateway(
@@ -96,7 +111,7 @@ class TestGatewayCreateUpdateHandler:
         assert result == {"success": True, "twingate_id": "gateway-id", "ts": ANY}
         mock_api_client.gateway_update.assert_called_once_with(
             gateway_id="gateway-id",
-            remote_network_id=ANY,
+            remote_network_id="UmVtb3RlTmV0d29yazoxMjMK",
             address="gateway.default.svc.cluster.local:443",
             x509_ca_id="ca-backend-id",
         )

--- a/app/tests/test_crds_gateway.py
+++ b/app/tests/test_crds_gateway.py
@@ -39,6 +39,18 @@ def test_gateway_deserialization(sample_gateway_object):
     )
 
 
+def test_gateway_remote_network_id_defaults_to_settings(sample_gateway_object):
+    gateway = TwingateGatewayCRD(**sample_gateway_object)
+    # `_mock_settings` (app/conftest.py) sets the operator-wide default.
+    assert gateway.spec.remote_network_id == "UmVtb3RlTmV0d29yazoxMjMK"
+
+
+def test_gateway_remote_network_id_override(sample_gateway_object):
+    sample_gateway_object["spec"]["remoteNetworkId"] = "UmVtb3RlTmV0d29yazo5OTkK"
+    gateway = TwingateGatewayCRD(**sample_gateway_object)
+    assert gateway.spec.remote_network_id == "UmVtb3RlTmV0d29yazo5OTkK"
+
+
 def test_gateway_service_ref_required():
     with pytest.raises(ValidationError, match="serviceRef"):
         GatewaySpec(x509_certificate_authority_ref={"name": "my-ca"})

--- a/deploy/twingate-operator/crds/twingate.com.twingategateway.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingategateway.yaml
@@ -18,10 +18,17 @@ spec:
               type: object
               description: "TwingateGatewaySpec defines the desired state of TwingateGateway"
               required: ["serviceRef", "x509CertificateAuthorityRef"]
+              x-kubernetes-validations:
+                - rule: (!has(oldSelf.remoteNetworkId) || self.remoteNetworkId == oldSelf.remoteNetworkId)
+                  message: "remoteNetworkId is immutable once set"
               properties:
                 id:
                   type: string
                   nullable: true
+                remoteNetworkId:
+                  type: string
+                  pattern: "^[-A-Za-z0-9+/]*={0,3}$"
+                  description: "ID of the Twingate Remote Network this Gateway belongs to. Overrides the operator-wide default (TWINGATE_REMOTE_NETWORK_ID). Immutable once set."
                 serviceRef:
                   type: object
                   required: ["name", "port"]

--- a/tests_integration/test_crds_gateway.py
+++ b/tests_integration/test_crds_gateway.py
@@ -2,7 +2,12 @@ import subprocess
 
 import pytest
 
-from tests_integration.utils import kubectl_create, kubectl_delete
+from tests_integration.utils import (
+    kubectl_apply,
+    kubectl_create,
+    kubectl_delete,
+    kubectl_get,
+)
 
 
 def test_success(unique_resource_name):
@@ -34,6 +39,87 @@ def test_spec_is_required(unique_resource_name):
 
     stderr = ex.value.stderr.decode()
     assert "spec: Required value" in stderr
+
+
+def test_remote_network_id(unique_resource_name):
+    result = kubectl_create(f"""
+        apiVersion: twingate.com/v1beta
+        kind: TwingateGateway
+        metadata:
+          name: {unique_resource_name}
+        spec:
+          remoteNetworkId: "UmVtb3RlTmV0d29yazoxMjMK"
+          serviceRef:
+            name: my-gateway-svc
+            port: 443
+          x509CertificateAuthorityRef:
+            name: my-ca
+    """)
+
+    assert result.returncode == 0
+
+    data = kubectl_get("tggw", unique_resource_name)
+    assert data["spec"]["remoteNetworkId"] == "UmVtb3RlTmV0d29yazoxMjMK"
+
+    kubectl_delete("tggw", unique_resource_name)
+
+
+def test_remote_network_id_invalid_pattern(unique_resource_name):
+    with pytest.raises(subprocess.CalledProcessError) as ex:
+        kubectl_create(f"""
+            apiVersion: twingate.com/v1beta
+            kind: TwingateGateway
+            metadata:
+              name: {unique_resource_name}
+            spec:
+              remoteNetworkId: "not valid!"
+              serviceRef:
+                name: my-gateway-svc
+                port: 443
+              x509CertificateAuthorityRef:
+                name: my-ca
+        """)
+
+    stderr = ex.value.stderr.decode()
+    assert "spec.remoteNetworkId in body should match" in stderr
+
+
+def test_remote_network_id_is_immutable(unique_resource_name):
+    result = kubectl_create(f"""
+        apiVersion: twingate.com/v1beta
+        kind: TwingateGateway
+        metadata:
+          name: {unique_resource_name}
+        spec:
+          remoteNetworkId: "UmVtb3RlTmV0d29yazoxMjMK"
+          serviceRef:
+            name: my-gateway-svc
+            port: 443
+          x509CertificateAuthorityRef:
+            name: my-ca
+    """)
+    assert result.returncode == 0
+
+    try:
+        with pytest.raises(subprocess.CalledProcessError) as ex:
+            kubectl_apply(f"""
+                apiVersion: twingate.com/v1beta
+                kind: TwingateGateway
+                metadata:
+                  name: {unique_resource_name}
+                spec:
+                  remoteNetworkId: "UmVtb3RlTmV0d29yazo0NTYK"
+                  serviceRef:
+                    name: my-gateway-svc
+                    port: 443
+                  x509CertificateAuthorityRef:
+                    name: my-ca
+            """)
+
+        stderr = ex.value.stderr.decode()
+        assert "remoteNetworkId is immutable once set" in stderr
+    finally:
+        kubectl_delete("tggw", unique_resource_name)
 
 
 def test_service_ref_required(unique_resource_name):


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #1037
- Follows #1094 (same field on `TwingateResource` / `TwingateConnector`)

## Changes

Add optional `remoteNetworkId` to the **TwingateGateway** CRD spec, so a Gateway can be placed
in the same Remote Network as the Resources it serves.

- Falls back to the operator-wide `TWINGATE_REMOTE_NETWORK_ID` when omitted
- Validated with the same base64 GlobalID `pattern` as `TwingateResource` /
  `TwingateConnector`, and immutable once set
