### PR TITLE
feat: Prepare Gateway service's `TwingateResource` for v2 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # CHANGELOG
 
 
+## v1.3.0 (2026-07-30)
+
+### Features
+
+- Keep the Kubernetes Resource when the Service annotation is removed
+  ([`92dc59c`](https://github.com/Twingate/kubernetes-operator/commit/92dc59cf97478c074b18c7415d753410d5d5166f))
+
+- Let Helm adopt the generated Kubernetes Resource
+  ([`bdf69f2`](https://github.com/Twingate/kubernetes-operator/commit/bdf69f24a556d398126c789d01b8d1e16c0cb2e5))
+
+
 ## v1.2.0 (2026-07-27)
 
 ### Chores

--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -41,6 +41,25 @@ UPSTREAM_PORT_ANNOTATION = "resource.twingate.com/upstreamPort"
 REQUEST_HEADER_REWRITES_ANNOTATION = "resource.twingate.com/requestHeaderRewrites"
 
 
+# Metadata that lets Helm take over the generated Kubernetes Resource, which v2's Gateway
+# chart declares under the same name. This operator has to write it while it is still the
+# one running, since Helm checks ownership when the v2 chart is applied.
+# TODO: Remove in v2, which declares and owns the Resource from the start.
+HELM_OWNERSHIP_ANNOTATIONS = (
+    "meta.helm.sh/release-name",
+    "meta.helm.sh/release-namespace",
+)
+HELM_MANAGED_BY_LABEL = "app.kubernetes.io/managed-by"
+# Labels identifying the chart revision that rendered the Service. They describe the
+# Service rather than the Resource derived from it, and copying them makes the operator
+# the owning field manager of values that go stale on the next chart bump, which then
+# collides with Helm's server-side apply when it declares the same labels.
+HELM_CHART_REVISION_LABELS = (
+    "helm.sh/chart",
+    "app.kubernetes.io/version",
+)
+
+
 def get_load_balancer_address(status: Status, service_name: str) -> str:
     if not (ingress := status.get("loadBalancer", {}).get("ingress")):
         raise kopf.TemporaryError(
@@ -101,6 +120,24 @@ def service_to_twingate_resource(service_body: Body, namespace: str) -> dict:
                 f"Unsupported resource type {unsupported!r}; "
                 f"must be one of {[t.value for t in ResourceType]}."
             )
+
+    # v2's Gateway chart declares the Kubernetes Resource itself, under the same name
+    # this generates, and Helm refuses to take over an existing object that doesn't
+    # already carry both annotations and the managed-by label. Propagate them from the
+    # Helm-deployed Service so that upgrade doesn't fail on invalid ownership metadata.
+    # The label is set explicitly rather than relied on from the Service, which need not
+    # label itself even when Helm renders it.
+    #
+    # Only for the Kubernetes type: nothing else is handed over to Helm, and marking a
+    # Resource as Helm-owned tells v2's operator to drop its Service owner reference,
+    # which is the only thing that cleans up a Resource when its Service is deleted.
+    if result["spec"].get("type") == ResourceType.KUBERNETES and all(
+        key in meta.annotations for key in HELM_OWNERSHIP_ANNOTATIONS
+    ):
+        result["metadata"]["annotations"] = {
+            key: meta.annotations[key] for key in HELM_OWNERSHIP_ANNOTATIONS
+        }
+        result["metadata"]["labels"][HELM_MANAGED_BY_LABEL] = "Helm"
 
     return result
 
@@ -253,6 +290,15 @@ def twingate_service_create(body, spec, namespace, meta, logger, reason, **_):
 
     resource_subobject = service_to_twingate_resource(body, namespace)
     kopf.adopt(resource_subobject)
+    # Only the Kubernetes Resource is handed over to Helm, and only its labels collide
+    # with Helm's server-side apply. Labels also become Twingate tags when syncLabels is
+    # on, so dropping them from any other Resource would change its tags in Twingate.
+    #
+    # `kopf.adopt` copies the owner's labels onto the child, so this has to run after it
+    # rather than while building the object, or the Service's copies come straight back.
+    if resource_subobject["spec"].get("type") == ResourceType.KUBERNETES:
+        for label in HELM_CHART_REVISION_LABELS:
+            resource_subobject["metadata"]["labels"].pop(label, None)
 
     resource_object_name = resource_subobject["metadata"]["name"]
 
@@ -268,6 +314,12 @@ def twingate_service_create(body, spec, namespace, meta, logger, reason, **_):
         existing_resource_object["metadata"]["labels"] = resource_subobject["metadata"][
             "labels"
         ]
+        # Merge rather than replace: the existing object also carries kopf's own
+        # annotations, and dropping those would lose its handler state.
+        if helm_annotations := resource_subobject["metadata"].get("annotations"):
+            existing_resource_object["metadata"]["annotations"] = (
+                existing_resource_object["metadata"].get("annotations") or {}
+            ) | helm_annotations
         kapi.replace_namespaced_custom_object(
             "twingate.com",
             "v1beta",
@@ -313,17 +365,24 @@ def twingate_service_annotation_removed(body, spec, namespace, meta, logger, **_
         # TwingateResource itself, so deleting here would deprovision the backend
         # Resource mid-upgrade. Leave it for the v2 chart to adopt. Deleting the Service
         # outright is unaffected: the owner reference still garbage-collects the object.
+        #
+        # v2 keeps this guard as a safety net. The annotations are expected to be removed
+        # while this operator is still running, but if the removal is only observed after
+        # the upgrade, the event lands on v2, which would then delete the Resource its
+        # chart now owns.
+        # TODO: Remove once no v1 operator is still running in the field, and in v3 at
+        # the latest.
         if existing_resource_object["spec"].get("type") == ResourceType.KUBERNETES:
             logger.warning(
-                "Not deleting TwingateResource %s: Kubernetes Resources are migrated to "
-                "TwingateGateway in v2. Delete it explicitly to deprovision.",
+                "Not deleting TwingateResource %s: Kubernetes Resources are kept so the "
+                "v2 Gateway chart can adopt them. Delete it explicitly to deprovision.",
                 resource_object_name,
             )
             kopf.info(
                 body,
                 reason="twingate_service_annotation_removed",
-                message=f"Kept Kubernetes TwingateResource {resource_object_name} "
-                "for migration to TwingateGateway",
+                message=f"Kept Kubernetes TwingateResource {resource_object_name}; "
+                "delete it explicitly to deprovision",
             )
             return
 

--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -309,6 +309,24 @@ def twingate_service_annotation_removed(body, spec, namespace, meta, logger, **_
     if existing_resource_object := k8s_get_twingate_resource(
         namespace, resource_object_name, kapi
     ):
+        # In v2 the Gateway chart drops these annotations and declares the
+        # TwingateResource itself, so deleting here would deprovision the backend
+        # Resource mid-upgrade. Leave it for the v2 chart to adopt. Deleting the Service
+        # outright is unaffected: the owner reference still garbage-collects the object.
+        if existing_resource_object["spec"].get("type") == ResourceType.KUBERNETES:
+            logger.warning(
+                "Not deleting TwingateResource %s: Kubernetes Resources are migrated to "
+                "TwingateGateway in v2. Delete it explicitly to deprovision.",
+                resource_object_name,
+            )
+            kopf.info(
+                body,
+                reason="twingate_service_annotation_removed",
+                message=f"Kept Kubernetes TwingateResource {resource_object_name} "
+                "for migration to TwingateGateway",
+            )
+            return
+
         logger.info("Deleting TwingateResource: %s", existing_resource_object)
         kapi.delete_namespaced_custom_object(
             "twingate.com",

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -656,6 +656,28 @@ class TestTwingateServiceAnnotationRemoved:
             "my-service-resource",
         )
 
+    def test_does_not_delete_kubernetes_twingate_resource(
+        self, example_service_body, kopf_handler_runner, k8s_customobjects_client_mock
+    ):
+        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = {
+            "metadata": {"name": "my-service-resource"},
+            "spec": {
+                "id": "1",
+                "name": "my-service-resource",
+                "type": ResourceType.KUBERNETES,
+            },
+        }
+
+        twingate_service_annotation_removed(
+            example_service_body,
+            example_service_body.spec,
+            "default",
+            example_service_body.metadata,
+            MagicMock(),
+        )
+
+        k8s_customobjects_client_mock.delete_namespaced_custom_object.assert_not_called()
+
     def test_does_not_delete_when_twingate_resource_does_not_exist(
         self, example_service_body, kopf_handler_runner, k8s_customobjects_client_mock
     ):

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -18,6 +18,11 @@ from app.handlers.handlers_services import (
 
 # Ignore the fact we use _cogs here
 
+HELM_OWNERSHIP_METADATA = {
+    "meta.helm.sh/release-name": "twingate-operator",
+    "meta.helm.sh/release-namespace": "twingate",
+}
+
 
 @pytest.fixture
 def example_service_body():
@@ -199,6 +204,51 @@ class TestServiceToTwingateResource:
 
         result = service_to_twingate_resource(example_service_body, "default")
         assert result == expected
+
+    def test_marks_kubernetes_resource_as_helm_owned(
+        self, example_cluster_ip_gateway_service_body
+    ):
+        example_cluster_ip_gateway_service_body.metadata["annotations"].update(
+            HELM_OWNERSHIP_METADATA
+        )
+
+        result = service_to_twingate_resource(
+            example_cluster_ip_gateway_service_body, "default"
+        )
+
+        assert result["metadata"]["annotations"] == HELM_OWNERSHIP_METADATA
+        assert result["metadata"]["labels"]["app.kubernetes.io/managed-by"] == "Helm"
+
+    @pytest.mark.parametrize("annotation", HELM_OWNERSHIP_METADATA)
+    def test_does_not_mark_as_helm_owned_on_partial_ownership_metadata(
+        self, example_cluster_ip_gateway_service_body, annotation
+    ):
+        # Helm won't adopt on a subset of the ownership annotations, so propagating one
+        # only sets the managed-by label, which makes v2's operator drop the Service
+        # owner reference without Helm ever taking over.
+        example_cluster_ip_gateway_service_body.metadata["annotations"][annotation] = (
+            HELM_OWNERSHIP_METADATA[annotation]
+        )
+
+        result = service_to_twingate_resource(
+            example_cluster_ip_gateway_service_body, "default"
+        )
+
+        assert "annotations" not in result["metadata"]
+        assert "app.kubernetes.io/managed-by" not in result["metadata"]["labels"]
+
+    def test_does_not_mark_other_resource_types_as_helm_owned(
+        self, example_service_body
+    ):
+        # Only the Kubernetes Resource is handed over to Helm. Marking any other one
+        # would make v2's operator drop its Service owner reference, which is the only
+        # thing that cleans it up when the Service goes away.
+        example_service_body.metadata["annotations"].update(HELM_OWNERSHIP_METADATA)
+
+        result = service_to_twingate_resource(example_service_body, "default")
+
+        assert "annotations" not in result["metadata"]
+        assert "app.kubernetes.io/managed-by" not in result["metadata"]["labels"]
 
     def test_kubernetes_resource_type_annotation(
         self, example_cluster_ip_gateway_service_body
@@ -626,6 +676,122 @@ class TestTwingateServiceCreate:
             updated_resource,
         )
         k8s_customobjects_client_mock.create_namespaced_custom_object.assert_not_called()
+
+    def test_create_drops_chart_revision_labels_from_kubernetes_resource(
+        self,
+        example_cluster_ip_gateway_service_body,
+        kopf_handler_runner,
+        kopf_adopt_mock,
+        k8s_customobjects_client_mock,
+    ):
+        example_cluster_ip_gateway_service_body.metadata["annotations"].update(
+            HELM_OWNERSHIP_METADATA
+        )
+        example_cluster_ip_gateway_service_body.metadata["labels"].update(
+            {
+                "helm.sh/chart": "gateway-0.21.1",
+                "app.kubernetes.io/version": "0.21.1",
+                "app.kubernetes.io/name": "gateway",
+            }
+        )
+        # Mirror kopf.adopt, which copies the owner's labels onto the child, so this
+        # covers the ordering: filtering before the adopt call would be undone by it.
+        kopf_adopt_mock.side_effect = lambda obj: [
+            obj["metadata"]["labels"].setdefault(key, value)
+            for key, value in example_cluster_ip_gateway_service_body.metadata[
+                "labels"
+            ].items()
+        ]
+        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = None
+
+        twingate_service_create(
+            example_cluster_ip_gateway_service_body,
+            example_cluster_ip_gateway_service_body.spec,
+            "default",
+            example_cluster_ip_gateway_service_body.metadata,
+            MagicMock(),
+            Reason.CREATE,
+        )
+
+        created = (
+            k8s_customobjects_client_mock.create_namespaced_custom_object.call_args[0][
+                4
+            ]
+        )
+        assert created["metadata"]["labels"] == {
+            "env": "dev",
+            "app.kubernetes.io/name": "gateway",
+            "app.kubernetes.io/managed-by": "Helm",
+        }
+
+    def test_create_keeps_chart_revision_labels_on_other_resource_types(
+        self,
+        example_service_body,
+        kopf_handler_runner,
+        kopf_adopt_mock,
+        k8s_customobjects_client_mock,
+    ):
+        # Labels become Twingate tags when syncLabels is on, so only the Resource handed
+        # over to Helm loses them.
+        chart_labels = {
+            "helm.sh/chart": "myapp-1.2.3",
+            "app.kubernetes.io/version": "1.2.3",
+        }
+        example_service_body.metadata["labels"].update(chart_labels)
+        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = None
+
+        twingate_service_create(
+            example_service_body,
+            example_service_body.spec,
+            "default",
+            example_service_body.metadata,
+            MagicMock(),
+            Reason.CREATE,
+        )
+
+        created = (
+            k8s_customobjects_client_mock.create_namespaced_custom_object.call_args[0][
+                4
+            ]
+        )
+        assert created["metadata"]["labels"] == {"env": "dev"} | chart_labels
+
+    def test_update_service_merges_helm_annotations_into_existing_resource(
+        self,
+        example_cluster_ip_gateway_service_body,
+        kopf_handler_runner,
+        k8s_customobjects_client_mock,
+    ):
+        example_cluster_ip_gateway_service_body.metadata["annotations"].update(
+            HELM_OWNERSHIP_METADATA
+        )
+        kopf_annotation = {"kopf.zalando.org/last-handled-configuration": "{}"}
+        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = {
+            "metadata": {
+                "name": "kubernetes-gateway-resource",
+                "labels": {},
+                "annotations": dict(kopf_annotation),
+            },
+            "spec": {"id": "1", "name": "kubernetes-gateway-resource"},
+        }
+
+        twingate_service_create(
+            example_cluster_ip_gateway_service_body,
+            example_cluster_ip_gateway_service_body.spec,
+            "default",
+            example_cluster_ip_gateway_service_body.metadata,
+            MagicMock(),
+            Reason.UPDATE,
+        )
+
+        replaced = (
+            k8s_customobjects_client_mock.replace_namespaced_custom_object.call_args[0][
+                5
+            ]
+        )
+        assert replaced["metadata"]["annotations"] == (
+            kopf_annotation | HELM_OWNERSHIP_METADATA
+        )
 
 
 class TestTwingateServiceAnnotationRemoved:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "twingate-operator"
-version = "1.2.0"
+version = "1.3.0"
 description = ""
 authors = ["Eran Kampf <eran@twingate.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/1037#issue-4623560178

## Changes

- Set Helm ownership annotation on Gateway service's `TwingateResource` object so Helm can adopt the object when upgrading to v2.
- Add logic to not delete Gateway service's `TwingateResource` when the `resource.twingate.com: true` annotation is removed from the Gateway service