### PR TITLE
feat: Repair Kubernetes Resources left behind by the v2 upgrade

### DIFF
--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -43,10 +43,14 @@ def _repair_missing_gateway_ref(name, namespace, spec, patch, logger) -> bool:
 
     # Only adopt a Gateway whose serviceRef points at the Service this Resource was
     # generated from, so a same-named but unrelated Gateway can't capture the access.
-    if gateway.get("spec", {}).get("serviceRef", {}).get("name") != gateway_name:
+    # serviceRef.namespace defaults to the Gateway's own, matching resolve_namespace().
+    service_ref = gateway.get("spec", {}).get("serviceRef", {})
+    service_ref_namespace = service_ref.get("namespace") or namespace
+    if service_ref.get("name") != gateway_name or service_ref_namespace != namespace:
         raise kopf.PermanentError(
-            f"TwingateGateway '{gateway_name}' does not reference Service "
-            f"'{gateway_name}'; set gatewayRef on '{name}' explicitly."
+            f"TwingateGateway '{gateway_name}' references Service "
+            f"'{service_ref_namespace}/{service_ref.get('name')}' instead of "
+            f"'{namespace}/{gateway_name}'; set gatewayRef on '{name}' explicitly."
         )
 
     logger.info("Binding Resource %s to TwingateGateway %s", name, gateway_name)

--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -12,13 +12,12 @@ from app.utils_k8s import k8s_get_twingate_custom_object
 def _repair_missing_gateway_ref(name, namespace, spec, patch, logger) -> bool:
     """Bind a Kubernetes Resource that the v2 upgrade left without a ``gatewayRef``.
 
-    Resources generated from a Service's annotations predate ``gatewayRef``, and Helm
+    Resources generated from a Service's annotations predate ``gatewayRef``, and Helm 3
     cannot fill it in on upgrade: it adopts the object once the ownership annotations
-    are present but never applies the manifest to it, because custom resources do not
-    get the three-way merge built-in types do (helm/helm#11650). The field's value is
-    identical in every chart revision too, so it never appears in a Helm diff either.
-    Server-side apply (Helm 4, Argo CD) does write it, so this only repairs the objects
-    left behind by clients that don't.
+    are present but never patches custom resources the way it does built-in types
+    (helm/helm#11650), so no later revision recovers the field either. Server-side apply
+    (Helm 4, Argo CD) does write it, so this only repairs the objects left behind by
+    clients that don't.
 
     Returns True when a repair was staged on ``patch``.
     """
@@ -42,17 +41,41 @@ def _repair_missing_gateway_ref(name, namespace, spec, patch, logger) -> bool:
             delay=30,
         )
 
-    # Only adopt a Gateway that fronts the Service this Resource was generated from,
-    # so a same-named but unrelated Gateway can't capture the cluster's access.
+    # Only adopt a Gateway whose serviceRef points at the Service this Resource was
+    # generated from, so a same-named but unrelated Gateway can't capture the access.
     if gateway.get("spec", {}).get("serviceRef", {}).get("name") != gateway_name:
         raise kopf.PermanentError(
-            f"TwingateGateway '{gateway_name}' does not front Service '{gateway_name}'; "
-            f"set gatewayRef on '{name}' explicitly."
+            f"TwingateGateway '{gateway_name}' does not reference Service "
+            f"'{gateway_name}'; set gatewayRef on '{name}' explicitly."
         )
 
     logger.info("Binding Resource %s to TwingateGateway %s", name, gateway_name)
     patch.spec["gatewayRef"] = {"name": gateway_name, "namespace": namespace}
     return True
+
+
+def _release_service_ownership(meta, spec, patch, logger):
+    """Drop the Service owner reference from a chart-declared Kubernetes Resource.
+
+    From v2 the Gateway chart declares the Resource the operator once generated from a
+    Service's annotations, so two owners claim one object: deleting the Service garbage
+    collects something the chart still declares, Helm or Argo CD applies it back without
+    a ``spec.id``, and the operator registers a second backend Resource.
+
+    v2 no longer generates a Kubernetes Resource from Service annotations, so only that
+    pre-v2 object matches. Network and WebApp Resources it still generates keep their
+    owner reference, since garbage collection is their only cleanup path.
+    """
+    if spec.get("type") != ResourceType.KUBERNETES:
+        return
+
+    owner_references = meta.get("ownerReferences") or []
+    remaining = [ref for ref in owner_references if ref.get("kind") != "Service"]
+    if len(remaining) == len(owner_references):
+        return
+
+    logger.info("Releasing Service ownership of Resource %s", meta.get("name"))
+    patch.meta["ownerReferences"] = remaining
 
 
 @kopf.on.create("twingateresource")
@@ -92,7 +115,7 @@ def twingate_resource_create(
 
 @kopf.on.update("twingateresource")
 def twingate_resource_update(
-    name, namespace, labels, spec, diff, status, memo, logger, patch, **kwargs
+    name, namespace, meta, labels, spec, diff, status, memo, logger, patch, **kwargs
 ):
     logger.info(
         "Got TwingateResource update request: %s. Labels: %s. Diff: %s. Status: %s.",
@@ -103,6 +126,8 @@ def twingate_resource_update(
     )
     if _repair_missing_gateway_ref(name, namespace, spec, patch, logger):
         raise kopf.TemporaryError("Staged gatewayRef; reconciling on retry.", delay=5)
+
+    _release_service_ownership(meta, spec, patch, logger)
 
     crd = ResourceSpec(**spec)
     labels = memo.twingate_settings.default_resource_tags | dict(labels)
@@ -161,10 +186,12 @@ RESOURCE_RECONCILER_IDLE = int(os.environ.get("RESOURCE_RECONCILER_IDLE", 60))  
     idle=RESOURCE_RECONCILER_IDLE,
 )
 def twingate_resource_sync(
-    name, namespace, labels, spec, status, memo, logger, patch, **kwargs
+    name, namespace, meta, labels, spec, status, memo, logger, patch, **kwargs
 ):
     if _repair_missing_gateway_ref(name, namespace, spec, patch, logger):
         raise kopf.TemporaryError("Staged gatewayRef; reconciling on retry.", delay=5)
+
+    _release_service_ownership(meta, spec, patch, logger)
 
     crd = ResourceSpec(**spec)
     labels = memo.twingate_settings.default_resource_tags | dict(labels)

--- a/app/handlers/handlers_resource.py
+++ b/app/handlers/handlers_resource.py
@@ -4,8 +4,55 @@ from datetime import timedelta
 import kopf
 
 from app.api import TwingateAPIClient
-from app.crds import ResourceSpec
+from app.crds import ResourceSpec, ResourceType, TwingateGatewayCRD
 from app.handlers.base import fail, success
+from app.utils_k8s import k8s_get_twingate_custom_object
+
+
+def _repair_missing_gateway_ref(name, namespace, spec, patch, logger) -> bool:
+    """Bind a Kubernetes Resource that the v2 upgrade left without a ``gatewayRef``.
+
+    Resources generated from a Service's annotations predate ``gatewayRef``, and Helm
+    cannot fill it in on upgrade: it adopts the object once the ownership annotations
+    are present but never applies the manifest to it, because custom resources do not
+    get the three-way merge built-in types do (helm/helm#11650). The field's value is
+    identical in every chart revision too, so it never appears in a Helm diff either.
+    Server-side apply (Helm 4, Argo CD) does write it, so this only repairs the objects
+    left behind by clients that don't.
+
+    Returns True when a repair was staged on ``patch``.
+    """
+    if spec.get("type") != ResourceType.KUBERNETES or spec.get("gatewayRef"):
+        return False
+
+    # The Gateway chart renders the Service and the TwingateGateway from one name
+    # helper, and the operator appended `-resource` when it generated this Resource
+    # from that Service, so dropping the suffix gives the Gateway's name.
+    gateway_name = name.removesuffix("-resource")
+    if gateway_name == name:
+        return False
+
+    gateway = k8s_get_twingate_custom_object(
+        TwingateGatewayCRD.PLURAL, namespace, gateway_name
+    )
+    if gateway is None:
+        raise kopf.TemporaryError(
+            f"Kubernetes Resource '{name}' has no gatewayRef and TwingateGateway "
+            f"'{gateway_name}' does not exist yet.",
+            delay=30,
+        )
+
+    # Only adopt a Gateway that fronts the Service this Resource was generated from,
+    # so a same-named but unrelated Gateway can't capture the cluster's access.
+    if gateway.get("spec", {}).get("serviceRef", {}).get("name") != gateway_name:
+        raise kopf.PermanentError(
+            f"TwingateGateway '{gateway_name}' does not front Service '{gateway_name}'; "
+            f"set gatewayRef on '{name}' explicitly."
+        )
+
+    logger.info("Binding Resource %s to TwingateGateway %s", name, gateway_name)
+    patch.spec["gatewayRef"] = {"name": gateway_name, "namespace": namespace}
+    return True
 
 
 @kopf.on.create("twingateresource")
@@ -45,7 +92,7 @@ def twingate_resource_create(
 
 @kopf.on.update("twingateresource")
 def twingate_resource_update(
-    namespace, labels, spec, diff, status, memo, logger, **kwargs
+    name, namespace, labels, spec, diff, status, memo, logger, patch, **kwargs
 ):
     logger.info(
         "Got TwingateResource update request: %s. Labels: %s. Diff: %s. Status: %s.",
@@ -54,6 +101,9 @@ def twingate_resource_update(
         diff,
         status,
     )
+    if _repair_missing_gateway_ref(name, namespace, spec, patch, logger):
+        raise kopf.TemporaryError("Staged gatewayRef; reconciling on retry.", delay=5)
+
     crd = ResourceSpec(**spec)
     labels = memo.twingate_settings.default_resource_tags | dict(labels)
     graphql_arguments = crd.to_graphql_arguments(
@@ -111,8 +161,11 @@ RESOURCE_RECONCILER_IDLE = int(os.environ.get("RESOURCE_RECONCILER_IDLE", 60))  
     idle=RESOURCE_RECONCILER_IDLE,
 )
 def twingate_resource_sync(
-    namespace, labels, spec, status, memo, logger, patch, **kwargs
+    name, namespace, labels, spec, status, memo, logger, patch, **kwargs
 ):
+    if _repair_missing_gateway_ref(name, namespace, spec, patch, logger):
+        raise kopf.TemporaryError("Staged gatewayRef; reconciling on retry.", delay=5)
+
     crd = ResourceSpec(**spec)
     labels = memo.twingate_settings.default_resource_tags | dict(labels)
     if resource_id := crd.id:

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -1,9 +1,11 @@
 from unittest.mock import ANY, MagicMock, patch
 
+import kopf
 import pytest
 
 from app.crds import ResourceSpec, ResourceType
 from app.handlers.handlers_resource import (
+    _repair_missing_gateway_ref,
     twingate_resource_create,
     twingate_resource_delete,
     twingate_resource_gateway_index,
@@ -57,6 +59,108 @@ def mock_memo_with_default_resource_tags():
             },
         )
     )
+
+
+class TestRepairMissingGatewayRef:
+    @pytest.fixture
+    def mock_get_custom_object(self):
+        with patch(
+            "app.handlers.handlers_resource.k8s_get_twingate_custom_object"
+        ) as mock:
+            yield mock
+
+    @pytest.fixture
+    def patch_mock(self):
+        mock = MagicMock()
+        mock.spec = {}
+        return mock
+
+    def test_binds_to_the_gateway_fronting_the_same_service(
+        self, mock_get_custom_object, patch_mock
+    ):
+        mock_get_custom_object.return_value = {"spec": {"serviceRef": {"name": "gw"}}}
+
+        repaired = _repair_missing_gateway_ref(
+            "gw-resource",
+            "default",
+            {"type": ResourceType.KUBERNETES},
+            patch_mock,
+            MagicMock(),
+        )
+
+        assert repaired is True
+        assert patch_mock.spec == {"gatewayRef": {"name": "gw", "namespace": "default"}}
+        mock_get_custom_object.assert_called_once_with(
+            "twingategateways", "default", "gw"
+        )
+
+    def test_retries_while_the_gateway_does_not_exist_yet(
+        self, mock_get_custom_object, patch_mock
+    ):
+        mock_get_custom_object.return_value = None
+
+        with pytest.raises(kopf.TemporaryError):
+            _repair_missing_gateway_ref(
+                "gw-resource",
+                "default",
+                {"type": ResourceType.KUBERNETES},
+                patch_mock,
+                MagicMock(),
+            )
+
+        assert patch_mock.spec == {}
+
+    def test_refuses_a_gateway_fronting_a_different_service(
+        self, mock_get_custom_object, patch_mock
+    ):
+        mock_get_custom_object.return_value = {
+            "spec": {"serviceRef": {"name": "unrelated"}}
+        }
+
+        with pytest.raises(kopf.PermanentError):
+            _repair_missing_gateway_ref(
+                "gw-resource",
+                "default",
+                {"type": ResourceType.KUBERNETES},
+                patch_mock,
+                MagicMock(),
+            )
+
+        assert patch_mock.spec == {}
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            {"type": ResourceType.NETWORK},
+            {"type": ResourceType.WEB_APP, "gatewayRef": {"name": "gw"}},
+            {"type": ResourceType.KUBERNETES, "gatewayRef": {"name": "gw"}},
+        ],
+    )
+    def test_leaves_resources_that_need_no_repair_alone(
+        self, spec, mock_get_custom_object, patch_mock
+    ):
+        repaired = _repair_missing_gateway_ref(
+            "gw-resource", "default", spec, patch_mock, MagicMock()
+        )
+
+        assert repaired is False
+        assert patch_mock.spec == {}
+        mock_get_custom_object.assert_not_called()
+
+    def test_leaves_hand_authored_names_alone(self, mock_get_custom_object, patch_mock):
+        # Only Resources the operator generated from a Service carry the `-resource`
+        # suffix; anything else is user-authored and they must set gatewayRef.
+        repaired = _repair_missing_gateway_ref(
+            "my-cluster",
+            "default",
+            {"type": ResourceType.KUBERNETES},
+            patch_mock,
+            MagicMock(),
+        )
+
+        assert repaired is False
+        assert patch_mock.spec == {}
+        mock_get_custom_object.assert_not_called()
 
 
 class TestResourceCreateHandler:
@@ -283,6 +387,7 @@ class TestResourceUpdateHandler:
         patch_mock.spec = {}
 
         result = twingate_resource_update(
+            "my-resource",
             "default",
             mock_k8s_metadata["labels"],
             spec,
@@ -290,6 +395,7 @@ class TestResourceUpdateHandler:
             status,
             mock_memo_with_default_resource_tags,
             logger_mock,
+            patch_mock,
         )
         assert result == {
             "success": True,
@@ -324,8 +430,11 @@ class TestResourceUpdateHandler:
 
         logger_mock = MagicMock()
         status_mock = MagicMock()
+        patch_mock = MagicMock()
+        patch_mock.spec = {}
         with patch("app.crds.resolve_ref_to_twingate_id", return_value="gw-1"):
             result = twingate_resource_update(
+                name="my-resource",
                 namespace="default",
                 labels=mock_k8s_metadata["labels"],
                 spec=spec,
@@ -333,6 +442,7 @@ class TestResourceUpdateHandler:
                 status=status_mock,
                 memo=mock_memo,
                 logger=logger_mock,
+                patch=patch_mock,
             )
 
             assert result == {
@@ -363,6 +473,7 @@ class TestResourceUpdateHandler:
         patch_mock.spec = {}
 
         result = twingate_resource_update(
+            "my-resource",
             "default",
             mock_k8s_metadata["labels"],
             spec,
@@ -370,6 +481,7 @@ class TestResourceUpdateHandler:
             status,
             memo_mock,
             logger_mock,
+            patch_mock,
         )
         assert result == {
             "success": False,
@@ -406,6 +518,7 @@ class TestResourceUpdateHandler:
         patch_mock.spec = {}
 
         result = twingate_resource_update(
+            "my-resource",
             "default",
             mock_k8s_metadata["labels"],
             spec,
@@ -413,6 +526,7 @@ class TestResourceUpdateHandler:
             status,
             memo_mock,
             logger_mock,
+            patch_mock,
         )
         assert result == {
             "success": True,
@@ -448,6 +562,7 @@ class TestResourceUpdateHandler:
         patch_mock.spec = {}
 
         result = twingate_resource_update(
+            "my-resource",
             "default",
             mock_k8s_metadata["labels"],
             spec,
@@ -455,6 +570,7 @@ class TestResourceUpdateHandler:
             status,
             memo_mock,
             logger_mock,
+            patch_mock,
         )
         assert result == {
             "success": True,
@@ -509,6 +625,40 @@ class TestResourceDeleteHandler:
 
 
 class TestResourceSyncTimer:
+    def test_sync_repairs_a_resource_left_without_a_gateway_ref(
+        self, mock_api_client, mock_k8s_metadata, mock_memo
+    ):
+        # The timer is what reaches a pre-existing Resource, since no `on.resume`
+        # handler is registered for twingateresource.
+        patch_mock = MagicMock()
+        patch_mock.spec = {}
+
+        with (
+            patch(
+                "app.handlers.handlers_resource.k8s_get_twingate_custom_object",
+                return_value={"spec": {"serviceRef": {"name": "gw"}}},
+            ),
+            pytest.raises(kopf.TemporaryError),
+        ):
+            twingate_resource_sync(
+                "gw-resource",
+                "default",
+                mock_k8s_metadata["labels"],
+                {
+                    "id": "UmVzb3VyY2U6OTMxODE3",
+                    "address": "kubernetes.default.svc.cluster.local",
+                    "name": "my-cluster",
+                    "type": ResourceType.KUBERNETES,
+                },
+                {},
+                mock_memo,
+                MagicMock(),
+                patch_mock,
+            )
+
+        assert patch_mock.spec == {"gatewayRef": {"name": "gw", "namespace": "default"}}
+        mock_api_client.resource_update.assert_not_called()
+
     def test_sync_when_resource_exists_and_doesnt_need_update(
         self, network_resource_factory, mock_api_client, mock_k8s_metadata, mock_memo
     ):
@@ -530,6 +680,7 @@ class TestResourceSyncTimer:
         patch_mock.spec = {}
 
         twingate_resource_sync(
+            "my-resource",
             "default",
             mock_k8s_metadata["labels"],
             resource_spec.model_dump(by_alias=True),
@@ -565,6 +716,7 @@ class TestResourceSyncTimer:
         patch_mock.spec = {}
 
         twingate_resource_sync(
+            "my-resource",
             "default",
             mock_k8s_metadata["labels"],
             resource_spec.model_dump(by_alias=True),
@@ -606,6 +758,7 @@ class TestResourceSyncTimer:
         patch_mock.spec = {}
 
         twingate_resource_sync(
+            "my-resource",
             "default",
             mock_k8s_metadata["labels"],
             resource_spec.model_dump(by_alias=True),
@@ -651,6 +804,7 @@ class TestResourceSyncTimer:
 
         with patch("app.crds.resolve_ref_to_twingate_id", return_value="gw-1"):
             twingate_resource_sync(
+                "my-resource",
                 "default",
                 mock_k8s_metadata["labels"],
                 resource_spec.model_dump(by_alias=True),

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -5,6 +5,7 @@ import pytest
 
 from app.crds import ResourceSpec, ResourceType
 from app.handlers.handlers_resource import (
+    _release_service_ownership,
     _repair_missing_gateway_ref,
     twingate_resource_create,
     twingate_resource_delete,
@@ -75,7 +76,7 @@ class TestRepairMissingGatewayRef:
         mock.spec = {}
         return mock
 
-    def test_binds_to_the_gateway_fronting_the_same_service(
+    def test_binds_to_the_gateway_referencing_the_same_service(
         self, mock_get_custom_object, patch_mock
     ):
         mock_get_custom_object.return_value = {"spec": {"serviceRef": {"name": "gw"}}}
@@ -110,7 +111,7 @@ class TestRepairMissingGatewayRef:
 
         assert patch_mock.spec == {}
 
-    def test_refuses_a_gateway_fronting_a_different_service(
+    def test_refuses_a_gateway_referencing_a_different_service(
         self, mock_get_custom_object, patch_mock
     ):
         mock_get_custom_object.return_value = {
@@ -161,6 +162,77 @@ class TestRepairMissingGatewayRef:
         assert repaired is False
         assert patch_mock.spec == {}
         mock_get_custom_object.assert_not_called()
+
+
+SERVICE_OWNER_REF = {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "name": "gw",
+    "uid": "3dee908b-1d75-4a34-a20a-36c08da0c39c",
+    "controller": True,
+}
+KUBERNETES_SPEC = {"type": ResourceType.KUBERNETES, "gatewayRef": {"name": "gw"}}
+
+
+class TestReleaseServiceOwnership:
+    @pytest.fixture
+    def patch_mock(self):
+        mock = MagicMock()
+        mock.meta = {}
+        return mock
+
+    def test_drops_the_service_owner_reference(self, patch_mock):
+        _release_service_ownership(
+            {"name": "gw-resource", "ownerReferences": [SERVICE_OWNER_REF]},
+            KUBERNETES_SPEC,
+            patch_mock,
+            MagicMock(),
+        )
+
+        assert patch_mock.meta == {"ownerReferences": []}
+
+    @pytest.mark.parametrize(
+        "resource_type", [ResourceType.NETWORK, ResourceType.WEB_APP]
+    )
+    def test_keeps_ownership_of_resources_the_operator_still_generates(
+        self, resource_type, patch_mock
+    ):
+        # An annotation-generated Resource has no other cleanup path: nothing watches
+        # Service deletions, so garbage collection is what deprovisions it.
+        _release_service_ownership(
+            {"name": "gw-resource", "ownerReferences": [SERVICE_OWNER_REF]},
+            {"type": resource_type},
+            patch_mock,
+            MagicMock(),
+        )
+
+        assert patch_mock.meta == {}
+
+    def test_keeps_owner_references_from_other_kinds(self, patch_mock):
+        other_ref = {"kind": "TwingateGateway", "name": "gw", "uid": "other-uid"}
+
+        _release_service_ownership(
+            {
+                "name": "gw-resource",
+                "ownerReferences": [SERVICE_OWNER_REF, other_ref],
+            },
+            KUBERNETES_SPEC,
+            patch_mock,
+            MagicMock(),
+        )
+
+        assert patch_mock.meta == {"ownerReferences": [other_ref]}
+
+    @pytest.mark.parametrize("owner_references", [[], None])
+    def test_is_a_no_op_once_already_released(self, owner_references, patch_mock):
+        _release_service_ownership(
+            {"name": "gw-resource", "ownerReferences": owner_references},
+            KUBERNETES_SPEC,
+            patch_mock,
+            MagicMock(),
+        )
+
+        assert patch_mock.meta == {}
 
 
 class TestResourceCreateHandler:
@@ -389,6 +461,7 @@ class TestResourceUpdateHandler:
         result = twingate_resource_update(
             "my-resource",
             "default",
+            mock_k8s_metadata,
             mock_k8s_metadata["labels"],
             spec,
             diff,
@@ -436,6 +509,7 @@ class TestResourceUpdateHandler:
             result = twingate_resource_update(
                 name="my-resource",
                 namespace="default",
+                meta=mock_k8s_metadata,
                 labels=mock_k8s_metadata["labels"],
                 spec=spec,
                 diff=diff,
@@ -475,6 +549,7 @@ class TestResourceUpdateHandler:
         result = twingate_resource_update(
             "my-resource",
             "default",
+            mock_k8s_metadata,
             mock_k8s_metadata["labels"],
             spec,
             diff,
@@ -520,6 +595,7 @@ class TestResourceUpdateHandler:
         result = twingate_resource_update(
             "my-resource",
             "default",
+            mock_k8s_metadata,
             mock_k8s_metadata["labels"],
             spec,
             diff,
@@ -564,6 +640,7 @@ class TestResourceUpdateHandler:
         result = twingate_resource_update(
             "my-resource",
             "default",
+            mock_k8s_metadata,
             mock_k8s_metadata["labels"],
             spec,
             diff,
@@ -643,6 +720,7 @@ class TestResourceSyncTimer:
             twingate_resource_sync(
                 "gw-resource",
                 "default",
+                mock_k8s_metadata,
                 mock_k8s_metadata["labels"],
                 {
                     "id": "UmVzb3VyY2U6OTMxODE3",
@@ -682,6 +760,7 @@ class TestResourceSyncTimer:
         twingate_resource_sync(
             "my-resource",
             "default",
+            mock_k8s_metadata,
             mock_k8s_metadata["labels"],
             resource_spec.model_dump(by_alias=True),
             status,
@@ -718,6 +797,7 @@ class TestResourceSyncTimer:
         twingate_resource_sync(
             "my-resource",
             "default",
+            mock_k8s_metadata,
             mock_k8s_metadata["labels"],
             resource_spec.model_dump(by_alias=True),
             status,
@@ -760,6 +840,7 @@ class TestResourceSyncTimer:
         twingate_resource_sync(
             "my-resource",
             "default",
+            mock_k8s_metadata,
             mock_k8s_metadata["labels"],
             resource_spec.model_dump(by_alias=True),
             status,
@@ -806,6 +887,7 @@ class TestResourceSyncTimer:
             twingate_resource_sync(
                 "my-resource",
                 "default",
+                mock_k8s_metadata,
                 mock_k8s_metadata["labels"],
                 resource_spec.model_dump(by_alias=True),
                 status,

--- a/app/handlers/tests/test_handlers_resource.py
+++ b/app/handlers/tests/test_handlers_resource.py
@@ -76,10 +76,14 @@ class TestRepairMissingGatewayRef:
         mock.spec = {}
         return mock
 
+    @pytest.mark.parametrize(
+        "service_ref",
+        [{"name": "gw"}, {"name": "gw", "namespace": "default"}],
+    )
     def test_binds_to_the_gateway_referencing_the_same_service(
-        self, mock_get_custom_object, patch_mock
+        self, mock_get_custom_object, patch_mock, service_ref
     ):
-        mock_get_custom_object.return_value = {"spec": {"serviceRef": {"name": "gw"}}}
+        mock_get_custom_object.return_value = {"spec": {"serviceRef": service_ref}}
 
         repaired = _repair_missing_gateway_ref(
             "gw-resource",
@@ -111,12 +115,14 @@ class TestRepairMissingGatewayRef:
 
         assert patch_mock.spec == {}
 
+    @pytest.mark.parametrize(
+        "service_ref",
+        [{"name": "unrelated"}, {"name": "gw", "namespace": "other"}],
+    )
     def test_refuses_a_gateway_referencing_a_different_service(
-        self, mock_get_custom_object, patch_mock
+        self, mock_get_custom_object, patch_mock, service_ref
     ):
-        mock_get_custom_object.return_value = {
-            "spec": {"serviceRef": {"name": "unrelated"}}
-        }
+        mock_get_custom_object.return_value = {"spec": {"serviceRef": service_ref}}
 
         with pytest.raises(kopf.PermanentError):
             _repair_missing_gateway_ref(


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/1037

## Changes

Repair pre-v2 Kubernetes Resources in place, on both the update handler and the reconcile timer, so an upgraded cluster converges without anyone touching the object.

- Bind a Kubernetes Resource left without a `gatewayRef` to the `TwingateGateway` referencing the Service it was generated from
  - retries while that Gateway does not exist yet
  - refuses a same-named Gateway whose `serviceRef` points at another Service
  - leaves hand-authored names alone (no `-resource` suffix), so those still require an explicit `gatewayRef`
- Drop the Service owner reference from a Kubernetes Resource, leaving the chart as its only owner
  - Network and WebApp Resources the operator still generates from Service annotations keep theirs

## Notes

- Why an upgrade can't fix `gatewayRef` on its own: Helm 3 adopts the existing object once the ownership annotations are set, but never patches custom resources the way it does built-in types (helm/helm#11650), and the field's value is identical in every chart revision, so no later upgrade recovers it. Server-side apply (Helm 4, Argo CD) does write it, so this only repairs what other clients leave behind.
- Why the owner reference has to go: the chart now declares the same object garbage collection owns. Deleting the Service destroys something the release still declares, the client applies it back without a `spec.id`, and the operator registers a second backend Resource.
