### PR TITLE
ci: Ignore dependency cooldown setting for Gateway Helm chart

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
       time: "13:00"
     commit-message:
       prefix: "chore: "
+    cooldown:
+      exclude:
+        - gateway
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Related Tickets & Documents

- Issue:

## Changes

Github enabled 3 day cooldown by default for dependencies in July 14 ([blog](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/)). Gateway Helm chart is developed and released by Twingate so we want to avoid this cooldown for testing