### PR TITLE
test: Fix flaky teardown in `test_gateway_flows`

### DIFF
--- a/tests_integration/test_gateway_flows.py
+++ b/tests_integration/test_gateway_flows.py
@@ -152,6 +152,21 @@ def test_gateway_flows(run_kopf, random_name_generator):
             #    backend entity) until its dependent is gone.
             kubectl(f"delete twingategateway/{gw_name} tgca/{ca_name} --wait=false")
 
+            # Wait for the Gateway's in-use rejection before freeing it - otherwise
+            # the concurrent Resource delete can land first in the backend and the
+            # Gateway delete succeeds on its first attempt.
+            kubectl_wait_object(
+                "twingategateway",
+                gw_name,
+                lambda o: (
+                    "still in use by a Resource"
+                    in o["metadata"]["annotations"].get(
+                        "twingate.com/twingate_gateway_delete", ""
+                    )
+                ),
+                description="a recorded in-use delete retry",
+            )
+
             # Removing the Resource frees the Gateway, whose removal frees the CA.
             kubectl_delete_wait("tgr", resource_name)
             kubectl_delete_wait("twingategateway", gw_name, perform_deletion=False)


### PR DESCRIPTION
## Changes


Fix `test_gateway_flows` flaky failures (sample [failed build](https://github.com/Twingate/kubernetes-operator/actions/runs/30930872790/job/92522969302))
- Wait for the Gateway's recorded in-use delete retry before deleting the Resource that holds it. 