### PR TITLE
fix: Delete the gateway's Twingate CRs before the operator on uninstall

### DIFF
--- a/deploy/twingate-operator/templates/pre-delete-cleanup.yaml
+++ b/deploy/twingate-operator/templates/pre-delete-cleanup.yaml
@@ -24,16 +24,20 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: rancher/kubectl:v1.34.0
+          # Delete the Twingate custom resources while the operator is still running, so
+          # its delete handlers can deregister them from Twingate and drop
+          # `twingate.com/finalizer`.
           command:
             - kubectl
             - delete
-            - svc
             - --cascade=foreground
             - --timeout=30s
             - --ignore-not-found
             - -n
             - {{ .Release.Namespace }}
-            - {{ $gatewayName }}
+            - twingateresource/{{ $gatewayName }}-resource
+            - twingategateway/{{ $gatewayName }}
+            - twingatecertificateauthority/{{ $gatewayName }}-ca
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/twingate-operator/templates/pre-delete-cleanup.yaml
+++ b/deploy/twingate-operator/templates/pre-delete-cleanup.yaml
@@ -30,7 +30,6 @@ spec:
           command:
             - kubectl
             - delete
-            - --cascade=foreground
             - --timeout=30s
             - --ignore-not-found
             - -n

--- a/deploy/twingate-operator/tests/__snapshot__/pre-delete-cleanup_test.yaml.snap
+++ b/deploy/twingate-operator/tests/__snapshot__/pre-delete-cleanup_test.yaml.snap
@@ -21,7 +21,6 @@ should enable pre-delete cleanup job:
             - command:
                 - kubectl
                 - delete
-                - --cascade=foreground
                 - --timeout=30s
                 - --ignore-not-found
                 - -n

--- a/deploy/twingate-operator/tests/__snapshot__/pre-delete-cleanup_test.yaml.snap
+++ b/deploy/twingate-operator/tests/__snapshot__/pre-delete-cleanup_test.yaml.snap
@@ -21,13 +21,14 @@ should enable pre-delete cleanup job:
             - command:
                 - kubectl
                 - delete
-                - svc
                 - --cascade=foreground
                 - --timeout=30s
                 - --ignore-not-found
                 - -n
                 - NAMESPACE
-                - RELEASE-NAME-gateway
+                - twingateresource/RELEASE-NAME-gateway-resource
+                - twingategateway/RELEASE-NAME-gateway
+                - twingatecertificateauthority/RELEASE-NAME-gateway-ca
               image: rancher/kubectl:v1.34.0
               name: cleanup
               securityContext:


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/1121

## Changes

- `pre-delete` hook deletes the `TwingateResource`, `TwingateGateway` and `TwingateCertificateAuthority` by name, instead of only the gateway Service.

## Notes

When we do `helm uninstall`, the Operator is removed first before it can delete the subchart's CR objects. As a result, the Twingate Gateway/Resource/CA CRs are left dangling.

The hook was originally added in #710 for this same ordering problem.
