### PR TITLE
fix: Recreate `TwingateResource` when the k8s service's `resource.twingate.com/type` annotation value changes

### DIFF
--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -198,6 +198,10 @@ def twingate_service_create(body, spec, namespace, meta, logger, reason, **_):
     if existing_resource_object := k8s_get_twingate_resource(
         namespace, resource_object_name, kapi
     ):
+        _delete_if_resource_type_changes(
+            kapi, namespace, existing_resource_object, resource_subobject, body, logger
+        )
+
         logger.info("TwingateResource already exists: %s", existing_resource_object)
         existing_resource_object["spec"] = {
             "id": existing_resource_object["spec"]["id"],
@@ -229,6 +233,47 @@ def twingate_service_create(body, spec, namespace, meta, logger, reason, **_):
             reason=f"twingate_service_create ({reason.value})",
             message=f"Created TwingateResource {resource_object_name}",
         )
+
+
+def _delete_if_resource_type_changes(
+    kapi: kubernetes.client.CustomObjectsApi,
+    namespace: str,
+    existing_resource_object: dict,
+    resource_subobject: dict,
+    service_body: Body,
+    logger,
+) -> None:
+    """Delete a generated TwingateResource whose type no longer matches the Service.
+
+    ``spec.type`` is immutable, so the type change is applied by deleting the Resource
+    and raising ``kopf.TemporaryError`` so a later retry registers the replacement.
+    """
+    resource_object_name = existing_resource_object["metadata"]["name"]
+    existing_type = existing_resource_object["spec"].get("type", ResourceType.NETWORK)
+    desired_type = resource_subobject["spec"].get("type", ResourceType.NETWORK)
+    if existing_type == desired_type:
+        return
+
+    logger.info(
+        "Deleting TwingateResource %s to recreate it as %s",
+        resource_object_name,
+        desired_type,
+    )
+    kapi.delete_namespaced_custom_object(
+        "twingate.com", "v1beta", namespace, "twingateresources", resource_object_name
+    )
+    kopf.warn(
+        service_body,
+        reason="twingate_service_create",
+        message=f"Recreating TwingateResource {resource_object_name} as {desired_type}: "
+        "the Twingate Resource is deprovisioned and recreated with a new ID, and group "
+        "access is re-granted on the next TwingateResourceAccess reconcile",
+    )
+    raise kopf.TemporaryError(
+        f"Deleting TwingateResource {resource_object_name} to recreate it as "
+        f"{desired_type}.",
+        delay=5,
+    )
 
 
 # Use Tuple for the field to properly escape dots in the annotation key.

--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -63,9 +63,9 @@ def service_to_twingate_resource(service_body: Body, namespace: str) -> dict:
 
     match result["spec"].get("type"):
         case ResourceType.WEB_APP:
-            result["spec"] |= _web_app_spec(service_body, namespace)
+            result["spec"] |= web_app_spec(service_body, namespace)
         case None | ResourceType.NETWORK:
-            result["spec"]["protocols"] = _network_protocols(service_body)
+            result["spec"]["protocols"] = network_protocols(service_body)
         case unsupported:
             raise kopf.PermanentError(
                 f"Unsupported resource type {unsupported!r}; must be one of "
@@ -75,7 +75,7 @@ def service_to_twingate_resource(service_body: Body, namespace: str) -> dict:
     return result
 
 
-def _web_app_spec(service_body: Body, namespace: str) -> dict:
+def web_app_spec(service_body: Body, namespace: str) -> dict:
     meta = service_body.metadata
     spec = service_body.spec
     service_name = service_body.meta.name
@@ -94,27 +94,27 @@ def _web_app_spec(service_body: Body, namespace: str) -> dict:
     # downstream is the client-facing port and is arbitrary, so an explicit value
     # is not constrained to the Service's ports; it defaults to the Service's port.
     if downstream_port := meta.annotations.get(DOWNSTREAM_PORT_ANNOTATION):
-        downstream = _parse_port_annotation(DOWNSTREAM_PORT_ANNOTATION, downstream_port)
+        downstream = parse_port_annotation(DOWNSTREAM_PORT_ANNOTATION, downstream_port)
     else:
-        downstream = _default_service_port(
+        downstream = default_service_port(
             tcp_ports, DOWNSTREAM_PORT_ANNOTATION, service_name
         )
 
     # upstream is the Service's target port, so an explicit value must match a port
     # the Service exposes; it defaults to the Service's port.
     if upstream_port := meta.annotations.get(UPSTREAM_PORT_ANNOTATION):
-        upstream = _parse_port_annotation(UPSTREAM_PORT_ANNOTATION, upstream_port)
+        upstream = parse_port_annotation(UPSTREAM_PORT_ANNOTATION, upstream_port)
         if upstream not in tcp_ports:
             raise kopf.PermanentError(
                 f"{UPSTREAM_PORT_ANNOTATION} annotation ({upstream}) must match a "
                 f"TCP port exposed by the Service {service_name}."
             )
     else:
-        upstream = _default_service_port(
+        upstream = default_service_port(
             tcp_ports, UPSTREAM_PORT_ANNOTATION, service_name
         )
 
-    web_app_spec: dict = {
+    result: dict = {
         "gatewayRef": {
             "name": gateway_name,
             "namespace": meta.annotations.get(GATEWAY_NAMESPACE_ANNOTATION, namespace),
@@ -138,16 +138,16 @@ def _web_app_spec(service_body: Body, namespace: str) -> dict:
         ):
             raise kopf.PermanentError(invalid_msg)
 
-        web_app_spec["requestHeaderRewrites"] = [
+        result["requestHeaderRewrites"] = [
             {"name": name, "value": value} for name, value in parsed.items()
         ]
 
-    return web_app_spec
+    return result
 
 
 # Only Network resources use port-based protocols. WebApp resources configure
 # upstream/downstream on the gateway instead.
-def _network_protocols(service_body: Body) -> dict:
+def network_protocols(service_body: Body) -> dict:
     protocols: dict = {
         "allowIcmp": False,
         "tcp": {"policy": "RESTRICTED", "ports": []},
@@ -163,7 +163,7 @@ def _network_protocols(service_body: Body) -> dict:
     return protocols
 
 
-def _default_service_port(
+def default_service_port(
     tcp_ports: list[int], annotation: str, service_name: str
 ) -> int:
     if len(tcp_ports) != 1:
@@ -174,7 +174,7 @@ def _default_service_port(
     return tcp_ports[0]
 
 
-def _parse_port_annotation(annotation: str, value: str) -> int:
+def parse_port_annotation(annotation: str, value: str) -> int:
     try:
         return int(value)
     except ValueError:
@@ -198,7 +198,7 @@ def twingate_service_create(body, spec, namespace, meta, logger, reason, **_):
     if existing_resource_object := k8s_get_twingate_resource(
         namespace, resource_object_name, kapi
     ):
-        _delete_if_resource_type_changes(
+        delete_if_resource_type_changes(
             kapi, namespace, existing_resource_object, resource_subobject, body, logger
         )
 
@@ -235,7 +235,7 @@ def twingate_service_create(body, spec, namespace, meta, logger, reason, **_):
         )
 
 
-def _delete_if_resource_type_changes(
+def delete_if_resource_type_changes(
     kapi: kubernetes.client.CustomObjectsApi,
     namespace: str,
     existing_resource_object: dict,

--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -239,7 +239,7 @@ def _delete_if_resource_type_changes(
     kapi: kubernetes.client.CustomObjectsApi,
     namespace: str,
     existing_resource_object: dict,
-    resource_subobject: dict,
+    new_resource_object: dict,
     service_body: Body,
     logger,
 ) -> None:
@@ -250,14 +250,14 @@ def _delete_if_resource_type_changes(
     """
     resource_object_name = existing_resource_object["metadata"]["name"]
     existing_type = existing_resource_object["spec"].get("type", ResourceType.NETWORK)
-    desired_type = resource_subobject["spec"].get("type", ResourceType.NETWORK)
-    if existing_type == desired_type:
+    new_type = new_resource_object["spec"].get("type", ResourceType.NETWORK)
+    if existing_type == new_type:
         return
 
     logger.info(
         "Deleting TwingateResource %s to recreate it as %s",
         resource_object_name,
-        desired_type,
+        new_type,
     )
     kapi.delete_namespaced_custom_object(
         "twingate.com", "v1beta", namespace, "twingateresources", resource_object_name
@@ -265,13 +265,13 @@ def _delete_if_resource_type_changes(
     kopf.warn(
         service_body,
         reason="twingate_service_create",
-        message=f"Recreating TwingateResource {resource_object_name} as {desired_type}: "
+        message=f"Recreating TwingateResource {resource_object_name} as {new_type}: "
         "the Twingate Resource is deprovisioned and recreated with a new ID, and group "
         "access is re-granted on the next TwingateResourceAccess reconcile",
     )
     raise kopf.TemporaryError(
         f"Deleting TwingateResource {resource_object_name} to recreate it as "
-        f"{desired_type}.",
+        f"{new_type}.",
         delay=5,
     )
 

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -458,6 +458,93 @@ class TestTwingateServiceCreate:
         )
         k8s_customobjects_client_mock.create_namespaced_custom_object.assert_not_called()
 
+    def test_resource_type_change_deletes_twingate_resource(
+        self,
+        example_webapp_service_body,
+        kopf_handler_runner,
+        kopf_warn_mock,
+        k8s_customobjects_client_mock,
+    ):
+        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = {
+            "metadata": {"name": "web-app-resource", "labels": {}},
+            "spec": {"id": "1", "name": "web-app-resource", "type": "Network"},
+        }
+
+        with pytest.raises(kopf.TemporaryError, match=r"recreate it as WebApp"):
+            twingate_service_create(
+                example_webapp_service_body,
+                example_webapp_service_body.spec,
+                "default",
+                example_webapp_service_body.metadata,
+                MagicMock(),
+                Reason.UPDATE,
+            )
+
+        k8s_customobjects_client_mock.delete_namespaced_custom_object.assert_called_once_with(
+            "twingate.com", "v1beta", "default", "twingateresources", "web-app-resource"
+        )
+        k8s_customobjects_client_mock.replace_namespaced_custom_object.assert_not_called()
+        k8s_customobjects_client_mock.create_namespaced_custom_object.assert_not_called()
+
+    def test_removed_resource_type_annotation_deletes_twingate_resource(
+        self,
+        example_service_body,
+        kopf_handler_runner,
+        kopf_warn_mock,
+        k8s_customobjects_client_mock,
+    ):
+        # Without the annotation the desired type falls back to the CRD's Network default.
+        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = {
+            "metadata": {"name": "my-service-resource", "labels": {}},
+            "spec": {"id": "1", "name": "my-service-resource", "type": "WebApp"},
+        }
+
+        with pytest.raises(kopf.TemporaryError, match=r"recreate it as Network"):
+            twingate_service_create(
+                example_service_body,
+                example_service_body.spec,
+                "default",
+                example_service_body.metadata,
+                MagicMock(),
+                Reason.UPDATE,
+            )
+
+        k8s_customobjects_client_mock.delete_namespaced_custom_object.assert_called_once_with(
+            "twingate.com",
+            "v1beta",
+            "default",
+            "twingateresources",
+            "my-service-resource",
+        )
+        k8s_customobjects_client_mock.replace_namespaced_custom_object.assert_not_called()
+        k8s_customobjects_client_mock.create_namespaced_custom_object.assert_not_called()
+
+    def test_resource_type_change_recreates_twingate_resource_once_deleted(
+        self,
+        example_webapp_service_body,
+        kopf_handler_runner,
+        k8s_customobjects_client_mock,
+    ):
+        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = None
+
+        twingate_service_create(
+            example_webapp_service_body,
+            example_webapp_service_body.spec,
+            "default",
+            example_webapp_service_body.metadata,
+            MagicMock(),
+            Reason.UPDATE,
+        )
+
+        k8s_customobjects_client_mock.delete_namespaced_custom_object.assert_not_called()
+        k8s_customobjects_client_mock.create_namespaced_custom_object.assert_called_once_with(
+            "twingate.com",
+            "v1beta",
+            "default",
+            "twingateresources",
+            service_to_twingate_resource(example_webapp_service_body, "default"),
+        )
+
 
 class TestTwingateServiceAnnotationRemoved:
     def test_deletes_twingate_resource_when_it_exists(

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -398,6 +398,7 @@ class TestTwingateServiceCreate:
         )
 
         k8s_customobjects_client_mock.patch_namespaced_custom_object.assert_not_called()
+        k8s_customobjects_client_mock.delete_namespaced_custom_object.assert_not_called()
         k8s_customobjects_client_mock.create_namespaced_custom_object.assert_called_once_with(
             "twingate.com",
             "v1beta",
@@ -458,19 +459,35 @@ class TestTwingateServiceCreate:
         )
         k8s_customobjects_client_mock.create_namespaced_custom_object.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("type_annotation", "existing_type", "new_type"),
+        [
+            ("WebApp", "Network", "WebApp"),
+            # Removing the annotation falls back to the CRD's Network default.
+            (None, "WebApp", "Network"),
+        ],
+    )
     def test_resource_type_change_deletes_twingate_resource(
         self,
         example_webapp_service_body,
         kopf_handler_runner,
         kopf_warn_mock,
         k8s_customobjects_client_mock,
+        type_annotation,
+        existing_type,
+        new_type,
     ):
+        annotations = example_webapp_service_body.metadata["annotations"]
+        if type_annotation:
+            annotations["resource.twingate.com/type"] = type_annotation
+        else:
+            del annotations["resource.twingate.com/type"]
         k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = {
             "metadata": {"name": "web-app-resource", "labels": {}},
-            "spec": {"id": "1", "name": "web-app-resource", "type": "Network"},
+            "spec": {"id": "1", "name": "web-app-resource", "type": existing_type},
         }
 
-        with pytest.raises(kopf.TemporaryError, match=r"recreate it as WebApp"):
+        with pytest.raises(kopf.TemporaryError, match=rf"recreate it as {new_type}"):
             twingate_service_create(
                 example_webapp_service_body,
                 example_webapp_service_body.spec,
@@ -485,65 +502,6 @@ class TestTwingateServiceCreate:
         )
         k8s_customobjects_client_mock.replace_namespaced_custom_object.assert_not_called()
         k8s_customobjects_client_mock.create_namespaced_custom_object.assert_not_called()
-
-    def test_removed_resource_type_annotation_deletes_twingate_resource(
-        self,
-        example_service_body,
-        kopf_handler_runner,
-        kopf_warn_mock,
-        k8s_customobjects_client_mock,
-    ):
-        # Without the annotation the new type falls back to the CRD's Network default.
-        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = {
-            "metadata": {"name": "my-service-resource", "labels": {}},
-            "spec": {"id": "1", "name": "my-service-resource", "type": "WebApp"},
-        }
-
-        with pytest.raises(kopf.TemporaryError, match=r"recreate it as Network"):
-            twingate_service_create(
-                example_service_body,
-                example_service_body.spec,
-                "default",
-                example_service_body.metadata,
-                MagicMock(),
-                Reason.UPDATE,
-            )
-
-        k8s_customobjects_client_mock.delete_namespaced_custom_object.assert_called_once_with(
-            "twingate.com",
-            "v1beta",
-            "default",
-            "twingateresources",
-            "my-service-resource",
-        )
-        k8s_customobjects_client_mock.replace_namespaced_custom_object.assert_not_called()
-        k8s_customobjects_client_mock.create_namespaced_custom_object.assert_not_called()
-
-    def test_resource_type_change_recreates_twingate_resource_once_deleted(
-        self,
-        example_webapp_service_body,
-        kopf_handler_runner,
-        k8s_customobjects_client_mock,
-    ):
-        k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = None
-
-        twingate_service_create(
-            example_webapp_service_body,
-            example_webapp_service_body.spec,
-            "default",
-            example_webapp_service_body.metadata,
-            MagicMock(),
-            Reason.UPDATE,
-        )
-
-        k8s_customobjects_client_mock.delete_namespaced_custom_object.assert_not_called()
-        k8s_customobjects_client_mock.create_namespaced_custom_object.assert_called_once_with(
-            "twingate.com",
-            "v1beta",
-            "default",
-            "twingateresources",
-            service_to_twingate_resource(example_webapp_service_body, "default"),
-        )
 
 
 class TestTwingateServiceAnnotationRemoved:

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -493,7 +493,7 @@ class TestTwingateServiceCreate:
         kopf_warn_mock,
         k8s_customobjects_client_mock,
     ):
-        # Without the annotation the desired type falls back to the CRD's Network default.
+        # Without the annotation the new type falls back to the CRD's Network default.
         k8s_customobjects_client_mock.get_namespaced_custom_object.return_value = {
             "metadata": {"name": "my-service-resource", "labels": {}},
             "spec": {"id": "1", "name": "my-service-resource", "type": "WebApp"},

--- a/tests_integration/test_service_flows.py
+++ b/tests_integration/test_service_flows.py
@@ -9,6 +9,7 @@ from tests_integration.utils import (
     kubectl_delete_wait,
     kubectl_get,
     kubectl_patch,
+    kubectl_wait_object,
     kubectl_wait_object_handler_success,
 )
 
@@ -418,6 +419,177 @@ def test_service_flows_with_webapp_resource(run_kopf, random_name_generator):
                 "syncLabels": True,
                 "type": "WebApp",
             }
+
+            # Deleting the service deletes the resource, then tear down the Gateway/CA.
+            kubectl_delete_wait("svc", service_name)
+            kubectl_delete_wait(
+                "twingateresource", resource_name, perform_deletion=False
+            )
+            kubectl_delete_wait("tggw", gw_name)
+            kubectl_delete_wait("tgca", ca_name)
+        finally:
+            # run_kopf only cleans up twingate CRs, not these helper objects.
+            kubectl(f"delete service {service_name} --ignore-not-found")
+            kubectl(f"delete service {gw_svc_name} --ignore-not-found")
+            kubectl(f"delete secret {secret_name} --ignore-not-found")
+
+    assert runner.exception is None
+    assert runner.exit_code == 0
+
+
+def test_service_flows_resource_type_change(run_kopf, random_name_generator):
+    secret_name = random_name_generator("gw-tls")
+    ca_name = random_name_generator("gw-ca")
+    gw_svc_name = random_name_generator("gw-svc")
+    gw_name = random_name_generator("gw")
+    gw_port = 8443
+    service_name = random_name_generator("test-svc")
+    resource_name = f"{service_name}-resource"
+
+    CA_OBJ = f"""
+        apiVersion: twingate.com/v1beta
+        kind: TwingateCertificateAuthority
+        metadata:
+          name: {ca_name}
+        spec:
+          name: {ca_name}
+          secretRef:
+            name: {secret_name}
+    """
+
+    GW_SERVICE_OBJ = f"""
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: {gw_svc_name}
+          namespace: default
+        spec:
+          type: ClusterIP
+          ports:
+            - protocol: TCP
+              port: {gw_port}
+              targetPort: {gw_port}
+          selector:
+            app.kubernetes.io/name: nonexistent
+    """
+
+    GW_OBJ = f"""
+        apiVersion: twingate.com/v1beta
+        kind: TwingateGateway
+        metadata:
+          name: {gw_name}
+        spec:
+          serviceRef:
+            name: {gw_svc_name}
+            port: {gw_port}
+          x509CertificateAuthorityRef:
+            name: {ca_name}
+    """
+
+    SERVICE_OBJ = f"""
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: {service_name}
+          annotations:
+            resource.twingate.com: "true"
+        spec:
+          selector:
+            app.kubernetes.io/name: MyApp
+          ports:
+            - name: http
+              protocol: TCP
+              port: 8080
+              targetPort: http
+    """
+
+    with run_kopf(
+        enable_connector_reconciler=False,
+        enable_group_reconciler=False,
+        enable_resource_reconciler=True,
+    ) as runner:
+        try:
+            # Changing the type to WebApp needs a synced Gateway, which needs a CA+Service.
+            kubectl_create(create_tls_secret(secret_name, generate_base64_ca_cert()))
+            kubectl_create(CA_OBJ)
+            kubectl_wait_object_handler_success(
+                "tgca", ca_name, "twingate_certificate_authority_create"
+            )
+            kubectl_create(GW_SERVICE_OBJ)
+            kubectl_create(GW_OBJ)
+            kubectl_wait_object_handler_success(
+                "tggw", gw_name, "twingate_gateway_create_update"
+            )
+
+            # The Service carries no type annotation, so it creates a Network Resource.
+            kubectl_create(SERVICE_OBJ)
+            tgr = kubectl_wait_object_handler_success(
+                "twingateresource", resource_name, "twingate_resource_create"
+            )
+            assert tgr["spec"]["type"] == "Network"
+            network_resource_id = tgr["spec"]["id"]
+
+            # spec.type is immutable, so the operator deletes the Resource and recreates
+            # it as a WebApp with a new Twingate ID.
+            kubectl_patch(
+                f"svc/{service_name}",
+                {
+                    "metadata": {
+                        "annotations": {
+                            "resource.twingate.com/type": "WebApp",
+                            "resource.twingate.com/gatewayName": gw_name,
+                        }
+                    }
+                },
+            )
+            tgr = kubectl_wait_object(
+                "twingateresource",
+                resource_name,
+                lambda obj: (
+                    obj["spec"].get("type") == "WebApp"
+                    and obj["spec"].get("id") not in (None, network_resource_id)
+                ),
+                description="recreation as a WebApp Resource",
+            )
+            assert tgr["spec"]["gatewayRef"] == {
+                "name": gw_name,
+                "namespace": "default",
+            }
+            # Both ports default to the Service's single TCP port.
+            assert tgr["spec"]["downstream"] == {"port": 8080}
+            assert tgr["spec"]["upstream"] == {"port": 8080}
+            assert "protocols" not in tgr["spec"]
+            web_app_resource_id = tgr["spec"]["id"]
+
+            # Removing only the type annotation converts back to a Network Resource. The
+            # gatewayName annotation is left behind on purpose: it is only read for WebApp
+            # Resources, so the recreated Network Resource must come out without a
+            # gatewayRef, which Network Resources are not allowed to have.
+            kubectl_patch(
+                f"svc/{service_name}",
+                [
+                    {
+                        "op": "remove",
+                        "path": "/metadata/annotations/resource.twingate.com~1type",
+                    }
+                ],
+                "json",
+            )
+            tgr = kubectl_wait_object(
+                "twingateresource",
+                resource_name,
+                lambda obj: (
+                    obj["spec"].get("type") == "Network"
+                    and obj["spec"].get("id") not in (None, web_app_resource_id)
+                ),
+                description="recreation as a Network Resource",
+            )
+            assert "gatewayRef" not in tgr["spec"]
+            assert "downstream" not in tgr["spec"]
+            assert "upstream" not in tgr["spec"]
+            assert tgr["spec"]["protocols"]["tcp"]["ports"] == [
+                {"start": 8080, "end": 8080}
+            ]
 
             # Deleting the service deletes the resource, then tear down the Gateway/CA.
             kubectl_delete_wait("svc", service_name)

--- a/tests_integration/utils.py
+++ b/tests_integration/utils.py
@@ -241,4 +241,8 @@ def kubectl_wait_object(
                 f"{resource_type}/{resource_name} did not reach {description}"
             )
         time.sleep(sleep_time)
-        obj = kubectl_get(resource_type, resource_name)
+        # Tolerate the object being absent mid-poll: an operator that recreates an object
+        # deletes it first, so it is briefly missing.
+        obj = kubectl_wait_to_exist(
+            resource_type, resource_name, max_retries=max_retries
+        )

--- a/tests_integration/utils.py
+++ b/tests_integration/utils.py
@@ -230,9 +230,15 @@ def kubectl_wait_object(
 ) -> dict:
     """Poll an object until ``predicate(obj)`` is truthy, then return it."""
     retry = 0
-    obj = kubectl_wait_to_exist(resource_type, resource_name, max_retries=max_retries)
     while True:
-        if predicate(obj):
+        try:
+            obj = kubectl_get(resource_type, resource_name)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            # Tolerate the object being absent: it may not exist yet, and an operator
+            # that recreates an object deletes it first, so it is briefly missing.
+            obj = None
+
+        if obj is not None and predicate(obj):
             return obj
 
         retry += 1
@@ -241,8 +247,3 @@ def kubectl_wait_object(
                 f"{resource_type}/{resource_name} did not reach {description}"
             )
         time.sleep(sleep_time)
-        # Tolerate the object being absent mid-poll: an operator that recreates an object
-        # deletes it first, so it is briefly missing.
-        obj = kubectl_wait_to_exist(
-            resource_type, resource_name, max_retries=max_retries
-        )


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/1037

## Changes

- Delete and re-register the generated `TwingateResource` when a Service's `resource.twingate.com/type` changes; `spec.type` is immutable and no backend mutation converts a Resource's type, so the in-place update was rejected and retried foreverl.

## Notes

- The recreated Resource has a new Twingate ID, so `TwingateResourceAccess` re-grants group access on its next reconcile rather than immediately
