### PR TITLE
fix: Relax `VERIFY_X509_STRICT` so the operator can reach the API server on EKS

### DIFF
--- a/app/ssl_compat.py
+++ b/app/ssl_compat.py
@@ -1,0 +1,140 @@
+"""Compatibility shim for Python 3.13+ strict X.509 verification.
+
+Python 3.13 added :data:`ssl.VERIFY_X509_STRICT` to the default verification
+flags of :func:`ssl.create_default_context`, and urllib3 2.x mirrors that
+default in ``create_urllib3_context``. The flag enforces RFC 5280 structural
+requirements, one of which is an Authority Key Identifier extension on the CA
+certificates in the chain.
+
+Amazon EKS cluster CAs are issued without an AKID, so every TLS connection to
+the API server fails with
+``SSLCertVerificationError: Missing Authority Key Identifier`` and the operator
+crashloops before it can reconcile anything. Both API server clients the
+operator uses are affected: kopf (aiohttp, via
+:meth:`kopf.ConnectionInfo.as_ssl_context`) and the ``kubernetes`` client
+(urllib3, used by :mod:`app.utils_k8s`).
+
+Clearing the flag restores the behavior of Python <= 3.12, which every operator
+release up to 1.1.2 shipped with. Chain validation, expiry checks,
+``CERT_REQUIRED`` and hostname verification all stay in force - only the RFC
+5280 structural strictness is dropped.
+
+Set ``TWINGATE_STRICT_X509_VERIFICATION=true`` to keep the Python 3.13+ default
+on clusters whose CA is RFC 5280 compliant.
+
+See https://github.com/Twingate/kubernetes-operator/issues/1128
+"""
+
+import functools
+import logging
+import os
+import ssl
+from typing import Any
+
+from app.utils import to_bool
+
+STRICT_ENV_VAR = "TWINGATE_STRICT_X509_VERIFICATION"
+
+_PATCHED_MARKER = "__twingate_x509_strict_relaxed__"
+
+
+def is_strict_x509_verification_enabled() -> bool:
+    """Whether the user opted back into the Python 3.13+ strict defaults."""
+    value = os.environ.get(STRICT_ENV_VAR, "").strip()
+    if not value:
+        return False
+
+    try:
+        return to_bool(value)
+    except ValueError:
+        logging.getLogger(__name__).warning(
+            "Ignoring unparseable %s=%r; assuming false.", STRICT_ENV_VAR, value
+        )
+        return False
+
+
+def relax_x509_strict(context: ssl.SSLContext) -> ssl.SSLContext:
+    """Clear ``VERIFY_X509_STRICT`` on ``context``, leaving all else intact."""
+    context.verify_flags &= ~ssl.VERIFY_X509_STRICT
+    return context
+
+
+def _patch_kopf() -> bool:
+    """Relax the SSL context kopf builds for the Kubernetes API server."""
+    from kopf import ConnectionInfo
+
+    original = ConnectionInfo.as_ssl_context
+    if getattr(original, _PATCHED_MARKER, False):
+        return False
+
+    @functools.wraps(original)
+    def as_ssl_context(self: ConnectionInfo) -> ssl.SSLContext:
+        return relax_x509_strict(original(self))
+
+    setattr(as_ssl_context, _PATCHED_MARKER, True)
+    ConnectionInfo.as_ssl_context = as_ssl_context  # type: ignore[method-assign]
+    return True
+
+
+def _patch_urllib3() -> bool:
+    """Relax the SSL contexts urllib3 builds, used by the ``kubernetes`` client.
+
+    ``create_urllib3_context`` is re-exported and bound by name in several
+    urllib3 modules, so every binding still pointing at the original has to be
+    replaced. Contexts the caller passed explicit ``verify_flags`` for are left
+    alone - that is a deliberate choice, not the implicit 3.13+ default.
+    """
+    import urllib3.connection
+    import urllib3.util
+    import urllib3.util.ssl_
+
+    original = urllib3.util.ssl_.create_urllib3_context
+    if getattr(original, _PATCHED_MARKER, False):
+        return False
+
+    @functools.wraps(original)
+    def create_urllib3_context(*args: Any, **kwargs: Any) -> ssl.SSLContext:
+        context = original(*args, **kwargs)
+        if kwargs.get("verify_flags") is None:
+            relax_x509_strict(context)
+        return context
+
+    setattr(create_urllib3_context, _PATCHED_MARKER, True)
+    for module in (urllib3.util.ssl_, urllib3.util, urllib3.connection):
+        if getattr(module, "create_urllib3_context", None) is original:
+            module.create_urllib3_context = create_urllib3_context  # type: ignore[attr-defined]
+
+    return True
+
+
+def apply_x509_strict_workaround(
+    logger: logging.Logger | logging.LoggerAdapter | None = None,
+) -> bool:
+    """Clear ``VERIFY_X509_STRICT`` from the SSL contexts the operator builds.
+
+    Returns ``True`` when the workaround was applied, ``False`` when it was
+    skipped - either opted out via :data:`STRICT_ENV_VAR` or already in place.
+    """
+    logger = logger or logging.getLogger(__name__)
+
+    if is_strict_x509_verification_enabled():
+        logger.info(
+            "%s is set - keeping strict RFC 5280 certificate verification. "
+            "Note that Amazon EKS cluster CAs carry no Authority Key Identifier "
+            "and will be rejected.",
+            STRICT_ENV_VAR,
+        )
+        return False
+
+    patched = _patch_kopf()
+    patched = _patch_urllib3() or patched
+
+    if patched:
+        logger.debug(
+            "Relaxed ssl.VERIFY_X509_STRICT for Kubernetes API connections; "
+            "certificate chain, expiry and hostname verification are unchanged. "
+            "Set %s=true to disable.",
+            STRICT_ENV_VAR,
+        )
+
+    return patched

--- a/app/tests/test_ssl_compat.py
+++ b/app/tests/test_ssl_compat.py
@@ -1,0 +1,140 @@
+import logging
+import ssl
+
+import pytest
+import urllib3.connection
+import urllib3.util
+import urllib3.util.ssl_
+from kopf import ConnectionInfo
+
+from app.ssl_compat import (
+    STRICT_ENV_VAR,
+    apply_x509_strict_workaround,
+    is_strict_x509_verification_enabled,
+    relax_x509_strict,
+)
+
+URLLIB3_MODULES = (urllib3.util.ssl_, urllib3.util, urllib3.connection)
+
+
+@pytest.fixture
+def unpatched(monkeypatch):
+    """Restore the stock kopf/urllib3 bindings after each test."""
+    monkeypatch.delenv(STRICT_ENV_VAR, raising=False)
+    monkeypatch.setattr(
+        ConnectionInfo, "as_ssl_context", ConnectionInfo.as_ssl_context, raising=True
+    )
+    for module in URLLIB3_MODULES:
+        monkeypatch.setattr(
+            module,
+            "create_urllib3_context",
+            module.create_urllib3_context,
+            raising=True,
+        )
+
+
+class TestRelaxX509Strict:
+    def test_clears_strict_flag(self):
+        """Fails if VERIFY_X509_STRICT survives."""
+        context = ssl.create_default_context()
+        assert context.verify_flags & ssl.VERIFY_X509_STRICT
+
+        relax_x509_strict(context)
+
+        assert not context.verify_flags & ssl.VERIFY_X509_STRICT
+
+    def test_keeps_the_rest_of_verification(self):
+        """Fails if anything other than the strict flag is weakened."""
+        context = ssl.create_default_context()
+        flags_before = context.verify_flags
+
+        relax_x509_strict(context)
+
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+        # Only the strict bit was touched; partial-chain etc. are untouched.
+        assert context.verify_flags == flags_before & ~ssl.VERIFY_X509_STRICT
+
+
+class TestIsStrictX509VerificationEnabled:
+    def test_unset(self, monkeypatch):
+        """Fails if the workaround is not the default."""
+        monkeypatch.delenv(STRICT_ENV_VAR, raising=False)
+        assert not is_strict_x509_verification_enabled()
+
+    @pytest.mark.parametrize("value", ["true", "True", "1", "yes", "on", " true "])
+    def test_truthy(self, monkeypatch, value):
+        """Fails if truthy opt-ins are not honored."""
+        monkeypatch.setenv(STRICT_ENV_VAR, value)
+        assert is_strict_x509_verification_enabled()
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", ""])
+    def test_falsy(self, monkeypatch, value):
+        """Fails if falsy values enable strict verification."""
+        monkeypatch.setenv(STRICT_ENV_VAR, value)
+        assert not is_strict_x509_verification_enabled()
+
+    def test_unparseable_does_not_raise(self, monkeypatch):
+        """Fails if a typo'd value crashes startup instead of falling back."""
+        monkeypatch.setenv(STRICT_ENV_VAR, "maybe")
+        assert not is_strict_x509_verification_enabled()
+
+
+class TestApplyX509StrictWorkaround:
+    def test_opted_out(self, unpatched, monkeypatch):
+        """Fails if the opt-out still patches anything."""
+        monkeypatch.setenv(STRICT_ENV_VAR, "true")
+        originals = {m: m.create_urllib3_context for m in URLLIB3_MODULES}
+        original_kopf = ConnectionInfo.as_ssl_context
+
+        assert apply_x509_strict_workaround(logging.getLogger(__name__)) is False
+
+        assert ConnectionInfo.as_ssl_context is original_kopf
+        for module, original in originals.items():
+            assert module.create_urllib3_context is original
+
+    def test_patches_kopf(self, unpatched):
+        """Fails if kopf's API-server context keeps the strict flag."""
+        assert apply_x509_strict_workaround() is True
+
+        context = ConnectionInfo(
+            server="https://kubernetes.default.svc"
+        ).as_ssl_context()
+
+        assert not context.verify_flags & ssl.VERIFY_X509_STRICT
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_patches_every_urllib3_binding(self, unpatched):
+        """Fails if a module-level re-export still points at the stock function.
+
+        ``urllib3.connection`` binds ``create_urllib3_context`` by name at import
+        time, so patching only ``urllib3.util.ssl_`` would leave the
+        ``kubernetes`` client on the strict default.
+        """
+        apply_x509_strict_workaround()
+
+        for module in URLLIB3_MODULES:
+            context = module.create_urllib3_context()
+            assert not context.verify_flags & ssl.VERIFY_X509_STRICT, module.__name__
+
+    def test_explicit_verify_flags_are_respected(self, unpatched):
+        """Fails if an explicit caller request is silently overridden."""
+        apply_x509_strict_workaround()
+
+        context = urllib3.connection.create_urllib3_context(
+            verify_flags=ssl.VERIFY_X509_STRICT
+        )
+
+        assert context.verify_flags & ssl.VERIFY_X509_STRICT
+
+    def test_is_idempotent(self, unpatched):
+        """Fails if repeated calls double-wrap the patched functions."""
+        assert apply_x509_strict_workaround() is True
+        patched_kopf = ConnectionInfo.as_ssl_context
+        patched_urllib3 = urllib3.connection.create_urllib3_context
+
+        assert apply_x509_strict_workaround() is False
+
+        assert ConnectionInfo.as_ssl_context is patched_kopf
+        assert urllib3.connection.create_urllib3_context is patched_urllib3

--- a/deploy/twingate-operator/values.yaml
+++ b/deploy/twingate-operator/values.yaml
@@ -145,6 +145,14 @@ priorityClassName: ""
 #   - name: FOO
 #     value: "bar"
 #
+# The operator relaxes ssl.VERIFY_X509_STRICT on connections to the Kubernetes
+# API server, because Amazon EKS cluster CAs have no Authority Key Identifier
+# and Python 3.13+ rejects them. Certificate chain, expiry and hostname
+# verification are unaffected. On a cluster with an RFC 5280 compliant CA you
+# can keep the strict Python default with:
+#   - name: TWINGATE_STRICT_X509_VERIFICATION
+#     value: "true"
+#
 extraEnvVars: []
 
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from app.handlers import *  # noqa: F403
 from app.settings import TwingateOperatorSettings
+from app.ssl_compat import apply_x509_strict_workaround
 
 
 class TwingateSmartProgressStorage(kopf.SmartProgressStorage):
@@ -31,6 +32,10 @@ def startup(
     **kwargs,
 ):
     logger.info("Operator is starting up...")
+
+    # Must run before kopf authenticates: Python 3.13+ rejects the EKS cluster CA
+    # for lacking an Authority Key Identifier (see app/ssl_compat.py).
+    apply_x509_strict_workaround(logger=logger)
 
     # Fixes issue where operator stops detecting changes (see https://github.com/nolar/kopf/issues/1120)
     settings.watching.connect_timeout = 60


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #1128 / [OSS-169](https://linear.app/twingate/issue/OSS-169)

## Changes

- Add `app/ssl_compat.py`, which clears `ssl.VERIFY_X509_STRICT` from the SSL contexts the operator builds for the Kubernetes API server.
- Patch **both** API-server clients: kopf/aiohttp (`kopf.ConnectionInfo.as_ssl_context`) and the `kubernetes` client (urllib3's `create_urllib3_context`).
- Apply it from the `@kopf.on.startup()` handler in `main.py`, which runs to completion before kopf's `credentials retriever` task starts, so it lands before the first login.
- Add `TWINGATE_STRICT_X509_VERIFICATION=true` as an opt-out for clusters with an RFC 5280 compliant CA, documented next to `extraEnvVars` in `values.yaml` (no chart template or CRD change needed).
- Add `app/tests/test_ssl_compat.py` (20 cases).

## Notes

### Root cause

Python 3.13 added `ssl.VERIFY_X509_STRICT` to the default `verify_flags` of `ssl.create_default_context()`, and urllib3 2.x [mirrors that default](https://github.com/urllib3/urllib3/blob/main/src/urllib3/util/ssl_.py). The flag enforces RFC 5280 structurally, including an Authority Key Identifier extension on the CA certificates in the chain.

Amazon EKS cluster CAs are issued **without** an AKID — the reporter verified this across 12+ clusters in multiple AWS accounts and regions; they carry only `Key Usage` and `Basic Constraints`. Operator images `>= 1.2.0` are built on Python 3.14 (`1.1.2` was 3.12.13), so every TLS connection to the API server fails and the pod crashloops:

```
SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
Missing Authority Key Identifier (_ssl.c:1081)')
```

This is a Python default, not an OpenSSL difference — the working `1.1.2` image and the broken `2.0.0` image link the identical OpenSSL 3.5.6. Rebuilding against a different OpenSSL would not help.

### Steps to reproduce

Install any operator image `>= 1.2.0` on an EKS cluster and watch `kubectl -n twingate logs -f deploy/twingate-operator`. #1128 also has a standalone two-pod A/B probe that isolates the failure from the operator entirely.

### This does not weaken verification

`CERT_REQUIRED`, `check_hostname`, chain validation and expiry checking all stay in force. Only the RFC 5280 structural strictness is dropped, restoring exactly what every release through `1.1.2` shipped:

```
before kopf   : True
before urllib3: True
after kopf    : False verify_mode= 2 check_hostname= True   # 2 == ssl.CERT_REQUIRED
after urllib3 : False
```

### Why both clients, not just kopf

The issue only shows kopf failing, because the pod crashlooped before any handler ran. But `app/utils_k8s.py` reads pods, secrets, deployments and services through the `kubernetes` client, which goes to the same API server over urllib3 and hits the same strict default. `kubernetes/client/rest.py` passes only `cert_reqs`/`ca_certs` to `PoolManager` and exposes no `ssl_context` hook, so that path needs its own patch — a kopf-only fix would start the operator and then fail on the first reconcile.

Note that `create_urllib3_context` is bound by name in three modules (`urllib3.util.ssl_`, `urllib3.util`, `urllib3.connection`), so all three bindings are rebound; there is a test asserting this specifically. Contexts where the caller passed explicit `verify_flags` are left alone.

### Alternatives considered

- **Patch `ssl.create_default_context` globally / a `sitecustomize.py` shim in the image** — larger blast radius, and invisible from the source tree. The targeted patches keep the change to the two clients we own and are unit-testable.
- **Apply at import time** — would give unit tests a global SSL side effect just for importing handlers. The startup handler runs early enough.
- **Pin the base image back to Python 3.12** — gives up 3.14 and only defers the problem.
- **Fix upstream in kopf** — worth raising, but does not cover the `kubernetes`/urllib3 path and would not unblock users on any timeline they can act on.

### Follow-up: 1.3.x backport still needed

This PR targets `main` (2.x) only. The [v1 → v2 migration guide](https://github.com/Twingate/kubernetes-operator/wiki/Migration-v1-to-v2) routes users through chart `1.3.0` to stamp Helm ownership metadata onto the gateway's `TwingateResource` — and `1.3.0`'s image is *also* Python 3.14, so **EKS users currently cannot take the documented migration path at all**. This commit needs a cherry-pick onto a `1.3.x` patch release to unblock that.

@anirudhbiyani offered to test a candidate image against their EKS fleet — worth taking them up on it before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
