### PR TITLE
chore: Remove `yq` github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,7 +241,6 @@ jobs:
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: 'v3.19.2'
-      - uses: chrisdickinson/setup-yq@3d931309f27270ebbafd53f2daee773a82ea1822 # v1.0.1
 
       - name: Set env vars
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,6 @@ jobs:
           installer-parallel: true
 
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-      - uses: chrisdickinson/setup-yq@3d931309f27270ebbafd53f2daee773a82ea1822 # v1.0.1
 
       - name: Set env vars
         run: |


### PR DESCRIPTION
## Related Tickets & Documents

- Issue:

## Changes

`chrisdickinson/setup-yq` is using Node.js 20.0 which is very old and results in warning. Also we don't use it...
```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: chrisdickinson/setup-yq@3d931309f27270ebbafd53f2daee773a82ea1822. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```