### PR TITLE
chore: Refuse to run integration tests outside the `minikube` context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ pinned versions. Keep this file as the single source of truth — when bumping P
 
 - Unit tests use `mocked_responses` and fixtures from `app/conftest.py`
 - Integration tests need `TWINGATE_API_KEY`, `TWINGATE_NETWORK`, `TWINGATE_REMOTE_NETWORK_ID`
+- Integration tests only run against the `minikube` kubectl context (override with `TWINGATE_ALLOWED_KUBE_CONTEXTS`)
 - Mock settings before importing handlers (loaded at module import time)
 
 ## Code Quality

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -40,6 +40,11 @@
    ```
 
 1. Run `make test-int` to see integration tests pass.
+
+   As a safeguard, integration tests apply CRDs and delete Twingate objects
+   cluster-wide, so they refuse to run unless the current kubectl context is
+   `minikube`. To deliberately target another cluster, set
+   `TWINGATE_ALLOWED_KUBE_CONTEXTS` to a comma-separated list of extra contexts.
 1. You can now edit code and run `make run` to run the operator locally.
    1. You'll also want to `poetry run pre-commit install` to make sure you have
       the pre-commit checks running locally.

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ DOCKER_BUILDX_CACHE ?=
 SEMANTIC_RELEASE_VERSION ?= 10.5.3
 SEMANTIC_RELEASE = pipx run --spec python-semantic-release==$(SEMANTIC_RELEASE_VERSION) semantic-release
 BUILD_ID ?= local
+KUBECTL_COMMAND ?= kubectl
 RELEASE_BRANCH_PATTERN ?= ^(main|master|hotfix(/.*)?)$$
 PROD_TAGS = $(shell ./scripts/split_semver.sh $(VERSION) | awk -v image="-t $(IMAGE_NAME)" '{ print image ":" $$0 }')
 
@@ -86,8 +87,19 @@ test: ##@tests Runs all tests
 test-cov: ##@tests Runs all tests with coverage
 	poetry run pytest --cov=app --cov-branch --cov-report html --cov-report xml --junitxml=junit.xml -o junit_family=legacy -m "not integration"
 
+.PHONY: check-kube-context
+check-kube-context: ##@tests Fails unless the current kubectl context is allowed for integration tests
+	@allowed="minikube$${TWINGATE_ALLOWED_KUBE_CONTEXTS:+,$$TWINGATE_ALLOWED_KUBE_CONTEXTS}"; \
+	ctx=$$($(KUBECTL_COMMAND) config current-context 2>/dev/null); \
+	if ! echo ",$$allowed," | grep -q ",$$ctx,"; then \
+		echo "Error: kube context '$$ctx' is not allowed for integration tests (allowed: $$allowed)."; \
+		echo "Integration tests apply CRDs and delete Twingate objects cluster-wide."; \
+		echo "Run 'minikube start && kubectl config use-context minikube', or set TWINGATE_ALLOWED_KUBE_CONTEXTS."; \
+		exit 1; \
+	fi
+
 .PHONY: test-int
-test-int: ##@tests Runs integration tests
+test-int: check-kube-context ##@tests Runs integration tests
 	poetry run pytest  -m "integration" -vv -l -x
 
 .PHONY: test-helm

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -10,7 +10,12 @@ import kopf
 import pytest
 from kopf.testing import KopfRunner
 
-from .utils import kubectl
+from .utils import (
+    ALLOWED_KUBE_CONTEXTS_ENV,
+    get_allowed_kube_contexts,
+    get_current_kube_context,
+    kubectl,
+)
 
 
 @pytest.fixture(scope="session")
@@ -20,7 +25,24 @@ def kopf_runner_args():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _load_crds():
+def _require_safe_kube_context():
+    allowed = get_allowed_kube_contexts()
+    current = get_current_kube_context()
+    if current in allowed:
+        return
+
+    pytest.exit(
+        f"Refusing to run integration tests against kube context {current!r}. "
+        f"They apply CRDs and delete Twingate objects cluster-wide, so they may "
+        f"only run against: {', '.join(sorted(allowed))}. "
+        f"Run `minikube start && kubectl config use-context minikube`, or set "
+        f"{ALLOWED_KUBE_CONTEXTS_ENV}=<context> to override deliberately.",
+        returncode=1,
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _load_crds(_require_safe_kube_context):
     kubectl("apply -f ./deploy/twingate-operator/crds/")
 
 

--- a/tests_integration/utils.py
+++ b/tests_integration/utils.py
@@ -12,6 +12,9 @@ from cryptography.x509.oid import NameOID
 
 KUBECTL_COMMAND = os.environ.get("KUBECTL_COMMAND", "kubectl")
 
+DEFAULT_ALLOWED_KUBE_CONTEXT = "minikube"
+ALLOWED_KUBE_CONTEXTS_ENV = "TWINGATE_ALLOWED_KUBE_CONTEXTS"
+
 # ruff: noqa: S602 (subprocess_popen_with_shell_equals_true)
 
 
@@ -75,6 +78,25 @@ def kubectl(command: str, input: str | None = None) -> subprocess.CompletedProce
         capture_output=True,
         input=input.encode() if input else None,
     )
+
+
+def get_allowed_kube_contexts() -> set[str]:
+    """Kubernetes contexts the integration tests are allowed to run against.
+
+    Defaults to just ``minikube``. ``TWINGATE_ALLOWED_KUBE_CONTEXTS`` (comma
+    separated) is a deliberate escape hatch for pointing at another cluster.
+    """
+    override = os.environ.get(ALLOWED_KUBE_CONTEXTS_ENV, "")
+    extra = {ctx.strip() for ctx in override.split(",") if ctx.strip()}
+    return {DEFAULT_ALLOWED_KUBE_CONTEXT} | extra
+
+
+def get_current_kube_context() -> str | None:
+    """The current kubectl context, or ``None`` if kubectl cannot report one."""
+    try:
+        return kubectl("config current-context").stdout.decode().strip() or None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return None
 
 
 def kubectl_create(obj: str) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: n/a

## Changes

- Add a session-scoped autouse `_require_safe_kube_context` fixture in `tests_integration/conftest.py` that `pytest.exit()`s unless the current kubectl context is `minikube`. `_load_crds` depends on it so fixture ordering can't regress.
- Add `check-kube-context` as a `test-int` Make prerequisite for a faster, clearer failure.
- Add `get_allowed_kube_contexts()` / `get_current_kube_context()` to `tests_integration/utils.py`, reusing the existing `kubectl()` wrapper so the check honours `KUBECTL_COMMAND`.
- Document the safeguard in `DEVELOPER.md` and `CLAUDE.md`.

## Notes

Integration tests drive a real cluster — `_load_crds` applies the CRDs and `run_kopf` teardown runs `kubectl delete twingate --all` — but nothing checked *which* cluster. A typical laptop kubeconfig has `minikube` in the same list as `twingate-prod-k8s-app-us-central1-prod-s1`, one `use-context` away.

The conftest fixture is the actual safeguard (covers `pytest -m integration` and IDE runs, not just `make test-int`); the Make target is only a nicer error. `TWINGATE_ALLOWED_KUBE_CONTEXTS` (comma-separated) is the escape hatch for deliberately targeting another cluster. Both guards fail closed when there's no current context.

CI is unaffected: `scripts/minikube-smoketests.sh` already runs `minikube start`.

Verified with a throwaway `KUBECONFIG`: both guards block a `fake-prod` context and an empty kubeconfig, the escape hatch lets it through, `test_crds_group.py` still passes against real minikube, and `make test` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
