### PR TITLE
fix: Stop retrying an unresolvable resource-access principal forever

### DIFF
--- a/app/handlers/handlers_resource_access.py
+++ b/app/handlers/handlers_resource_access.py
@@ -17,6 +17,16 @@ from app.utils_k8s import (
 
 K8sObject = MutableMapping[Any, Any]
 
+# Bound the principal lookup so a binding pointing at a principal that cannot be resolved
+# stops re-querying the API forever. The attempts are counted by Kopf per cause, so the
+# budget resets whenever the object's spec changes.
+PRINCIPAL_LOOKUP_MAX_ATTEMPTS = int(os.environ.get("PRINCIPAL_LOOKUP_MAX_ATTEMPTS", 3))
+PRINCIPAL_LOOKUP_RETRY_DELAY = int(os.environ.get("PRINCIPAL_LOOKUP_RETRY_DELAY", 15))
+
+
+class PrincipalLookupError(ValueError):
+    """The access grant's principal could not be resolved (yet)."""
+
 
 def get_principal_id(
     access_crd: ResourceAccessSpec,
@@ -32,9 +42,7 @@ def get_principal_id(
         if group_id := group_spec.get("id"):
             return group_id
 
-        raise kopf.TemporaryError(
-            "TwingateGroup object doesn't have an id yet. retrying...", delay=15
-        )
+        raise PrincipalLookupError("TwingateGroup object doesn't have an id yet.")
 
     if ref := access_crd.principal_external_ref:
         # Once `twingate_resource_access_change` ran and we have the principal_id we reuse it
@@ -47,14 +55,14 @@ def get_principal_id(
         elif ref.type == PrincipalTypeEnum.ServiceAccount:
             principal_id = client.get_service_account_id(ref.name)
         else:
-            raise ValueError(f"Unknown principal type: {ref.type}")
+            raise PrincipalLookupError(f"Unknown principal type: {ref.type}")
 
         if not principal_id:
-            raise ValueError(f"Principal {ref.type} {ref.name} not found.")
+            raise PrincipalLookupError(f"Principal {ref.type} {ref.name} not found.")
 
         return principal_id
 
-    raise ValueError("Missing principal_id or principal_external_ref")
+    raise PrincipalLookupError("Missing principal_id or principal_external_ref")
 
 
 def fetched_principal_id(status: dict | None) -> str | None:
@@ -63,6 +71,11 @@ def fetched_principal_id(status: dict | None) -> str | None:
         return None
 
     return get_recorded_access(status)["principalId"]
+
+
+def principal_lookup_failure(status: dict | None) -> dict | None:
+    """Return the give-up recorded for the current spec, if the lookup budget ran out."""
+    return (status or {}).get("principalLookupFailure")
 
 
 def get_recorded_access(status: dict | None) -> dict[str, str | None]:
@@ -77,8 +90,42 @@ def get_recorded_access(status: dict | None) -> dict[str, str | None]:
     }
 
 
+def resolve_principal_id(
+    access_crd: ResourceAccessSpec,
+    status: dict | None,
+    client: TwingateAPIClient,
+    owner_namespace: str,
+    body,
+    patch,
+    retry: int,
+) -> str:
+    """Resolve the principal, giving up for good after ``PRINCIPAL_LOOKUP_MAX_ATTEMPTS``."""
+    try:
+        return get_principal_id(access_crd, status, client, owner_namespace)
+    except PrincipalLookupError as err:
+        attempts = retry + 1
+        if attempts < PRINCIPAL_LOOKUP_MAX_ATTEMPTS:
+            raise kopf.TemporaryError(
+                f"{err} Retrying (attempt {attempts}/{PRINCIPAL_LOOKUP_MAX_ATTEMPTS}).",
+                delay=PRINCIPAL_LOOKUP_RETRY_DELAY,
+            ) from err
+
+        # Recorded so the sync timer, which starts each tick with a fresh attempt count,
+        # does not pick the same doomed lookup back up.
+        patch.status["principalLookupFailure"] = {
+            "attempts": attempts,
+            "error": str(err),
+        }
+        message = (
+            f"{err} Gave up after {attempts} attempts; "
+            "retrying only when the spec changes."
+        )
+        kopf.warn(body, reason="PrincipalLookupFailed", message=message)
+        raise kopf.PermanentError(message) from err
+
+
 def reconcile_resource_access(
-    body, namespace, spec, status, memo, logger, patch
+    body, namespace, spec, status, memo, logger, patch, retry=0
 ) -> dict:
     recorded_access = get_recorded_access(status)
 
@@ -95,7 +142,9 @@ def reconcile_resource_access(
     resource_id = resource_crd.spec.id
     try:
         client = TwingateAPIClient(memo.twingate_settings, logger=logger)
-        principal_id = get_principal_id(access_crd, status, client, namespace)
+        principal_id = resolve_principal_id(
+            access_crd, status, client, namespace, body, patch, retry
+        )
         # Delete before adding so that a failure leaves less access than intended.
         delete_old_access(client, recorded_access, resource_id, principal_id, logger)
         client.resource_access_add(
@@ -111,6 +160,7 @@ def reconcile_resource_access(
         # earlier in the status so the next reconcile still takes it away.
         patch.status["resourceId"] = resource_id
         patch.status["principalId"] = principal_id
+        patch.status["principalLookupFailure"] = None
 
         kopf.info(
             body,
@@ -147,10 +197,12 @@ def delete_old_access(
 @kopf.on.create("twingateresourceaccess")
 @kopf.on.update("twingateresourceaccess", field="spec")
 def twingate_resource_access_change(
-    body, namespace, spec, memo, logger, status, patch, **kwargs
+    body, namespace, spec, memo, logger, status, patch, retry=0, **kwargs
 ):
     logger.info("Got a TwingateResourceAccess create request: %s", spec)
-    return reconcile_resource_access(body, namespace, spec, status, memo, logger, patch)
+    return reconcile_resource_access(
+        body, namespace, spec, status, memo, logger, patch, retry
+    )
 
 
 def get_unmigrated_recorded_ids(status: dict | None) -> dict[str, str]:
@@ -191,7 +243,7 @@ ENABLE_RESOURCE_ACCESS_RECONCILER = os.environ.get(
     idle=60,
 )
 def twingate_resource_access_sync(
-    body, namespace, spec, memo, logger, patch, status, **kwargs
+    body, namespace, spec, memo, logger, patch, status, retry=0, **kwargs
 ):
     # Allow the reconciler to be temporarily disabled because tenants with large numbers of
     # resource access CRD objects can generate many write operations and get throttled. We currently
@@ -199,7 +251,20 @@ def twingate_resource_access_sync(
     if not to_bool(ENABLE_RESOURCE_ACCESS_RECONCILER):
         return None
 
-    return reconcile_resource_access(body, namespace, spec, status, memo, logger, patch)
+    # `twingate_resource_access_change` already exhausted the lookup budget for this spec.
+    # Reconciling here would only repeat the failed lookup on every tick, forever.
+    if failure := principal_lookup_failure(status):
+        logger.warning(
+            "Skipping sync: the principal lookup was given up after %s attempts (%s). "
+            "It is retried when the spec changes.",
+            failure["attempts"],
+            failure["error"],
+        )
+        return None
+
+    return reconcile_resource_access(
+        body, namespace, spec, status, memo, logger, patch, retry
+    )
 
 
 @kopf.on.delete("twingateresourceaccess")

--- a/app/handlers/tests/test_handlers_resource_access.py
+++ b/app/handlers/tests/test_handlers_resource_access.py
@@ -14,11 +14,13 @@ from app.crds import (
     K8sMetadata,
 )
 from app.handlers.handlers_resource_access import (
+    PrincipalLookupError,
     get_principal_id,
     has_unmigrated_recorded_access,
     twingate_group_id_changed,
     twingate_resource_access_by_group,
     twingate_resource_access_by_resource,
+    twingate_resource_access_change,
     twingate_resource_access_delete,
     twingate_resource_access_migrate_status,
     twingate_resource_access_sync,
@@ -62,15 +64,15 @@ class TestGetPrincipalId:
         access_crd.get_group_ref_object.return_value = {"spec": {"id": "group-id"}}
         assert get_principal_id(access_crd, None, MagicMock(), "default") == "group-id"
 
-    def test_id_from_group_ref_object_not_ready_raises_temoraryerror(self):
+    def test_id_from_group_ref_object_not_ready_raises_lookup_error(self):
         access_crd = MagicMock()
         access_crd.principal_id = None
         access_crd.principal_external_ref = None
         access_crd.get_group_ref_object.return_value = {"spec": {"id": None}}
-        with pytest.raises(kopf.TemporaryError):
-            assert (
-                get_principal_id(access_crd, None, MagicMock(), "default") == "group-id"
-            )
+        with pytest.raises(
+            PrincipalLookupError, match=r"TwingateGroup object doesn't have an id yet"
+        ):
+            get_principal_id(access_crd, None, MagicMock(), "default")
 
     def test_from_external_ref_group(self, mock_api_client):
         access_crd = MagicMock()
@@ -191,6 +193,7 @@ class TestResourceAccessChangeHandler:
         assert patch_shim.status == {
             "resourceId": resource_spec.id,
             "principalId": "R3JvdXA6MTE1NzI2MA==",
+            "principalLookupFailure": None,
         }
         kopf_info_mock.assert_called_once_with("", reason="Success", message=ANY)
 
@@ -492,6 +495,120 @@ class TestResourceAccessChangeHandler:
         assert call_kwargs["approval_mode"] == AccessApprovalMode.AUTOMATIC
 
 
+MISSING_PRINCIPAL_SPEC = {
+    "resourceRef": {"name": "a-resource"},
+    "principalExternalRef": {"type": "group", "name": "missing-group"},
+}
+
+
+class TestBoundedPrincipalLookup:
+    """The principal lookup is retried 3 times, then left until the spec changes."""
+
+    def run_change(self, patch_shim, retry, resource_spec, status=None):
+        resource_crd_mock = MagicMock()
+        resource_crd_mock.spec = resource_spec
+        resource_crd_mock.metadata = K8sMetadata(uid="uid", name="foo", namespace="bar")
+
+        with patch(
+            "app.handlers.handlers_resource_access.ResourceAccessSpec.get_resource",
+            return_value=resource_crd_mock,
+        ):
+            return twingate_resource_access_change(
+                body={},
+                namespace="default",
+                spec=MISSING_PRINCIPAL_SPEC,
+                memo=MagicMock(),
+                logger=MagicMock(),
+                patch=patch_shim,
+                status=status or {},
+                retry=retry,
+            )
+
+    @pytest.mark.parametrize("retry", [0, 1])
+    def test_retries_are_temporary_until_the_budget_runs_out(
+        self, retry, network_resource_factory, mock_api_client
+    ):
+        mock_api_client.get_group_id.return_value = None
+        patch_shim = SimpleNamespace(spec={}, status={})
+
+        with pytest.raises(kopf.TemporaryError, match=r"Principal group missing-group not found"):  # fmt: skip
+            self.run_change(patch_shim, retry, network_resource_factory().to_spec())
+
+        # Nothing is recorded while retries are still allowed, so the sync timer keeps working.
+        assert patch_shim.status == {}
+
+    def test_gives_up_permanently_on_the_last_attempt(
+        self, network_resource_factory, mock_api_client
+    ):
+        mock_api_client.get_group_id.return_value = None
+        patch_shim = SimpleNamespace(spec={}, status={})
+
+        with (
+            patch("kopf.warn") as kopf_warn_mock,
+            pytest.raises(kopf.PermanentError, match=r"Gave up after 3 attempts"),
+        ):
+            self.run_change(patch_shim, 2, network_resource_factory().to_spec())
+
+        assert patch_shim.status == {
+            "principalLookupFailure": {
+                "attempts": 3,
+                "error": "Principal group missing-group not found.",
+            }
+        }
+        kopf_warn_mock.assert_called_once_with(
+            {}, reason="PrincipalLookupFailed", message=ANY
+        )
+
+    def test_sync_skips_a_recorded_give_up(self, mock_api_client):
+        logger_mock = MagicMock()
+        result = twingate_resource_access_sync(
+            body={},
+            namespace="default",
+            spec=MISSING_PRINCIPAL_SPEC,
+            memo=MagicMock(),
+            logger=logger_mock,
+            patch=SimpleNamespace(spec={}, status={}),
+            status={
+                "principalLookupFailure": {
+                    "attempts": 3,
+                    "error": "Principal group missing-group not found.",
+                }
+            },
+        )
+
+        assert result is None
+        mock_api_client.get_group_id.assert_not_called()
+        logger_mock.warning.assert_called_once()
+
+    def test_the_budget_restarts_after_the_spec_changes(
+        self, network_resource_factory, kopf_info_mock, mock_api_client
+    ):
+        # Kopf counts the attempts per cause, so a spec change arrives with retry=0 even
+        # though the previous cause had given up.
+        mock_api_client.get_group_id.return_value = "a-group-id"
+        patch_shim = SimpleNamespace(spec={}, status={})
+        resource_spec = network_resource_factory().to_spec()
+
+        result = self.run_change(
+            patch_shim,
+            0,
+            resource_spec,
+            status={
+                "principalLookupFailure": {
+                    "attempts": 3,
+                    "error": "Principal group missing-group not found.",
+                }
+            },
+        )
+
+        assert result["success"] is True
+        assert patch_shim.status == {
+            "resourceId": resource_spec.id,
+            "principalId": "a-group-id",
+            "principalLookupFailure": None,
+        }
+
+
 class TestDeleteOldAccess:
     PRINCIPAL_ID = "R3JvdXA6MTE1NzI2MA=="
 
@@ -665,6 +782,7 @@ class TestDeleteOldAccess:
         assert patch_shim.status == {
             "resourceId": "new-resource-id",
             "principalId": self.PRINCIPAL_ID,
+            "principalLookupFailure": None,
         }
 
     def test_fails_when_the_deletion_is_rejected(

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -71,6 +71,7 @@ def run_kopf(kopf_runner_args, kopf_settings):
         enable_resource_reconciler=False,
         enable_resource_access_reconciler=True,
         cleanup=True,
+        extra_env=None,
     ):
         unload_operator_modules()
 
@@ -90,6 +91,10 @@ def run_kopf(kopf_runner_args, kopf_settings):
 
         if not enable_resource_access_reconciler:
             env["ENABLE_RESOURCE_ACCESS_RECONCILER"] = "false"
+
+        # The handlers read their knobs at import time, and `unload_operator_modules` above
+        # forces the re-import, so overrides passed here reach the operator.
+        env.update(extra_env or {})
 
         with KopfRunner(
             kopf_runner_args,

--- a/tests_integration/test_resource_flows.py
+++ b/tests_integration/test_resource_flows.py
@@ -1,4 +1,5 @@
 import os
+import time
 from unittest.mock import ANY
 
 import pytest
@@ -10,6 +11,7 @@ from tests_integration.utils import (
     kubectl_apply,
     kubectl_create,
     kubectl_delete_wait,
+    kubectl_get,
     kubectl_patch,
     kubectl_wait_object,
     kubectl_wait_object_handler_success,
@@ -513,6 +515,101 @@ def test_recorded_access_migrated_from_an_earlier_operator_version(
 
     logs = load_stdout(runner.output)
     assert_log_message_contains(logs, "Migrated the recorded access IDs")
+
+
+# The sync timer's idle/initial delays are both 60s, so this is how long the test has to
+# wait to prove the timer saw the object and declined to retry the lookup.
+SYNC_TIMER_WINDOW = 75
+
+
+def test_resource_access_stops_retrying_a_missing_principal(
+    run_kopf, unique_resource_name
+):
+    """A principal that cannot be resolved is retried 3 times, then left until the spec changes."""
+    assert "TWINGATE_TEST_PRINCIPAL_ID" in os.environ
+    principal_id = os.environ["TWINGATE_TEST_PRINCIPAL_ID"]
+    missing_group = f"no-such-group-{unique_resource_name}"
+
+    resource_obj = f"""
+        apiVersion: twingate.com/v1beta
+        kind: TwingateResource
+        metadata:
+          name: {unique_resource_name}
+        spec:
+          name: My K8S Resource
+          address: my.default.cluster.local
+    """
+
+    access_obj = ACCESS_OBJECTS["OBJ_ACCESS_BY_PRINCIPAL_NAME_GROUP"].format(
+        resource_name=unique_resource_name, principal_name=missing_group
+    )
+
+    # The sync timer is left on its default schedule so the test proves it stands down;
+    # only the retry delay is shortened so the 3 attempts do not take 30 seconds.
+    with run_kopf(extra_env={"PRINCIPAL_LOOKUP_RETRY_DELAY": "2"}) as runner:
+        kubectl_create(resource_obj)
+        resource = kubectl_wait_object_handler_success("tgr", unique_resource_name, "twingate_resource_create")  # fmt: skip
+        assert resource["spec"]["id"] is not None
+
+        kubectl_create(access_obj)
+        access = kubectl_wait_object(
+            "tacc",
+            unique_resource_name,
+            lambda obj: access_status(obj).get("principalLookupFailure") is not None,
+            description="a recorded principal-lookup give-up",
+        )
+        failure = access_status(access)["principalLookupFailure"]
+        assert failure["attempts"] == 3
+        assert missing_group in failure["error"]
+        assert "principalId" not in access_status(access)
+
+        # Nothing retries the lookup while the spec is unchanged - not even the sync timer.
+        time.sleep(SYNC_TIMER_WINDOW)
+        access = kubectl_get("tacc", unique_resource_name)
+        assert access_status(access)["principalLookupFailure"] == failure
+        assert "principalId" not in access_status(access)
+
+        # Changing the spec starts a new attempt budget. Patched rather than re-applied so
+        # `principalExternalRef` is actually removed - the CRD rejects it next to a principalId.
+        kubectl_patch(
+            f"tacc/{unique_resource_name}",
+            {
+                "spec": {
+                    "principalExternalRef": None,
+                    "principalId": principal_id,
+                }
+            },
+        )
+        # Polled on the recorded ID rather than the handler result: kopf suffixes the
+        # field-filtered update handler's id, so its result lands under
+        # `twingate_resource_access_change/spec`.
+        access = kubectl_wait_object(
+            "tacc",
+            unique_resource_name,
+            lambda obj: access_status(obj).get("principalId") == principal_id,
+            description=f"principalId {principal_id}",
+        )
+        assert "principalLookupFailure" not in access_status(access)
+
+        kubectl_delete_wait("tacc", unique_resource_name)
+        kubectl_delete_wait("tgr", unique_resource_name)
+
+    logs = load_stdout(runner.output)
+
+    # The group name only ever reaches the API as a GraphQL variable, so the outgoing
+    # queries are an exact count of how often the doomed lookup was attempted.
+    lookups = [
+        log
+        for log in logs
+        if log["message"].startswith(">>>") and missing_group in log["message"]
+    ]
+    assert len(lookups) == 3, f"expected 3 API lookups, got {len(lookups)}"
+
+    assert_log_message_contains(logs, "Retrying (attempt 1/3)")
+    assert_log_message_contains(logs, "Retrying (attempt 2/3)")
+    assert_log_message_contains(logs, "Gave up after 3 attempts")
+    # The sync timer ticked during the sleep above and declined to retry the lookup.
+    assert_log_message_contains(logs, "Skipping sync")
 
 
 def access_status(access_object: dict) -> dict:


### PR DESCRIPTION
## Related Tickets & Documents

- Issue:

## Changes

- `get_principal_id` raises `PrincipalLookupError` for every failure mode instead of a plain
  `ValueError`.
- The lookup is bounded to 3 attempts: the first two raise `kopf.TemporaryError`, the third records
  `status.principalLookupFailure`, emits a `PrincipalLookupFailed` event, and raises
  `kopf.PermanentError`. A successful reconcile clears the record.
- `twingate_resource_access_sync` skips an object carrying that record, so the 10-hour timer does not
  restart the budget on every tick.
- New knobs `PRINCIPAL_LOOKUP_MAX_ATTEMPTS` (3) and `PRINCIPAL_LOOKUP_RETRY_DELAY` (15s); `run_kopf`
  gains an `extra_env` passthrough for knobs the handlers read at import time.

## Notes

**Root cause.** `get_principal_id` raised a plain `ValueError`, and `twingate_resource_access_change`
has no `timeout=`/`retries=`. Kopf's default error mode is `TEMPORARY`, so the handler retried
forever — one `principalExternalRef` naming a nonexistent group produced an endless stream of GraphQL
lookups.

**Reproduce.** Create a `TwingateResourceAccess` whose `principalExternalRef` names a group that does
not exist. Before: `failed with an exception and will try again in 60 seconds`, indefinitely. After:
three attempts, then silence until the spec changes.

**Why no attempt counter of our own.** Kopf counts retries per cause, and the handler only runs on
create or a `spec` change, so its `retry` kwarg already means "attempts since the object changed".
The status record exists only to tell the sync timer to stand down, since each tick starts from
`retry=0`. Generation-keying it would not work: these CRDs have no `status` subresource, so status
writes bump `metadata.generation`.

`status.principalLookupFailure` needs no CRD change — `status` is already
`x-kubernetes-preserve-unknown-fields`. The `twingate_resource_id_changed` /
`twingate_group_id_changed` paths are unchanged, already bounded by
`RESOURCE_ACCESS_HANDLER_TIMEOUT`.

**Verification.** `make check`/`typecheck`/`test` clean; `test_resource_flows.py` and
`test_crds_resourceaccess.py` pass against minikube + a live tenant. Reverting only the handler makes
the new test fail (`did not reach a recorded principal-lookup give-up`), so it genuinely reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
