### PR TITLE
feat: Support HTTPS for `WebApp` resources

### DIFF
--- a/app/api/client_resources.py
+++ b/app/api/client_resources.py
@@ -298,8 +298,8 @@ class WebAppResource(BaseResource):
             fragment WebAppResourceFields on WebAppResource {
                 ...BaseResourceFields
                 gateway { id }
-                downstream { port }
-                upstream { port }
+                downstream { port tls }
+                upstream { port tls }
                 requestHeaderRewrites { name: key value }
             }
             """
@@ -326,15 +326,15 @@ class WebAppResource(BaseResource):
         if remote_gateway_id != crd_gateway_id:
             diff["gateway_id"] = Diff(remote=remote_gateway_id, local=crd_gateway_id)
 
-        crd_downstream_port = crd.downstream.port if crd.downstream else None
-        if self.downstream.port != crd_downstream_port:
-            diff["downstream"] = Diff(
-                remote=self.downstream.port, local=crd_downstream_port
-            )
+        downstream = self.downstream.model_dump()
+        crd_downstream = crd.downstream.model_dump() if crd.downstream else None
+        if downstream != crd_downstream:
+            diff["downstream"] = Diff(remote=downstream, local=crd_downstream)
 
-        crd_upstream_port = crd.upstream.port if crd.upstream else None
-        if self.upstream.port != crd_upstream_port:
-            diff["upstream"] = Diff(remote=self.upstream.port, local=crd_upstream_port)
+        upstream = self.upstream.model_dump()
+        crd_upstream = crd.upstream.model_dump() if crd.upstream else None
+        if upstream != crd_upstream:
+            diff["upstream"] = Diff(remote=upstream, local=crd_upstream)
 
         # Header rewrites are unordered, so compare them as name -> value dicts to
         # avoid spurious diffs from ordering.
@@ -380,8 +380,8 @@ QUERY_GET_RESOURCE = BaseResource.get_graphql_fragment() + """
             }
             ... on WebAppResource {
                 gateway { id }
-                downstream { port }
-                upstream { port }
+                downstream { port tls }
+                upstream { port tls }
                 requestHeaderRewrites { name: key value }
             }
         }

--- a/app/api/tests/test_client_resources.py
+++ b/app/api/tests/test_client_resources.py
@@ -251,8 +251,36 @@ class TestWebAppResourceModel:
             "app.api.client_resources.resolve_ref_to_twingate_id", return_value="gw-1"
         ):
             assert resource.get_spec_diff(crd, owner_namespace="default") == {
-                "downstream": Diff(remote=resource.downstream.port, local=8443),
-                "upstream": Diff(remote=resource.upstream.port, local=9090),
+                "downstream": Diff(
+                    remote={"port": resource.downstream.port, "tls": False},
+                    local={"port": 8443, "tls": False},
+                ),
+                "upstream": Diff(
+                    remote={"port": resource.upstream.port, "tls": False},
+                    local={"port": 9090, "tls": False},
+                ),
+            }
+
+    def test_get_spec_diff_for_tls_drift(self, web_app_resource_factory):
+        resource = web_app_resource_factory(gateway=ResourceGateway(id="gw-1"))
+        crd = resource.to_spec(
+            gateway_ref={"name": "my-gateway"},
+            downstream={"port": resource.downstream.port, "tls": True},
+            upstream={"port": resource.upstream.port, "tls": True},
+        )
+
+        with patch(
+            "app.api.client_resources.resolve_ref_to_twingate_id", return_value="gw-1"
+        ):
+            assert resource.get_spec_diff(crd, owner_namespace="default") == {
+                "downstream": Diff(
+                    remote={"port": resource.downstream.port, "tls": False},
+                    local={"port": resource.downstream.port, "tls": True},
+                ),
+                "upstream": Diff(
+                    remote={"port": resource.upstream.port, "tls": False},
+                    local={"port": resource.upstream.port, "tls": True},
+                ),
             }
 
     def test_get_spec_diff_ignores_protocols(self, web_app_resource_factory):
@@ -752,7 +780,11 @@ class TestTwingateResourceAPIs:
     def test_web_app_resource_create(
         self, test_url, api_client, web_app_resource_factory, mocked_responses
     ):
-        resource = web_app_resource_factory(gateway=ResourceGateway(id="gw-1"))
+        resource = web_app_resource_factory(
+            gateway=ResourceGateway(id="gw-1"),
+            downstream__tls=True,
+            upstream__tls=True,
+        )
         crd = resource.to_spec(
             id=None,
             gateway_ref={"name": "my-gateway"},
@@ -777,8 +809,14 @@ class TestTwingateResourceAPIs:
                     {
                         "variables": {
                             "gatewayId": "gw-1",
-                            "downstream": {"port": resource.downstream.port},
-                            "upstream": {"port": resource.upstream.port},
+                            "downstream": {
+                                "port": resource.downstream.port,
+                                "tls": resource.downstream.tls,
+                            },
+                            "upstream": {
+                                "port": resource.upstream.port,
+                                "tls": resource.upstream.tls,
+                            },
                         }
                     },
                     strict_match=False,

--- a/app/crds.py
+++ b/app/crds.py
@@ -154,6 +154,7 @@ class ResourceDownstream(BaseModel):
     )
 
     port: Port
+    tls: bool = False
 
 
 class ResourceUpstream(BaseModel):
@@ -162,6 +163,7 @@ class ResourceUpstream(BaseModel):
     )
 
     port: Port
+    tls: bool = False
 
 
 class RequestHeaderRewrite(BaseModel):

--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -35,8 +35,8 @@ ALLOWED_EXTRA_ANNOTATIONS: list[tuple[str, Callable]] = [
 GATEWAY_NAME_ANNOTATION = "resource.twingate.com/gatewayName"
 GATEWAY_NAMESPACE_ANNOTATION = "resource.twingate.com/gatewayNamespace"
 DOWNSTREAM_PORT_ANNOTATION = "resource.twingate.com/downstreamPort"
-UPSTREAM_PORT_ANNOTATION = "resource.twingate.com/upstreamPort"
 DOWNSTREAM_TLS_ANNOTATION = "resource.twingate.com/downstreamTLS"
+UPSTREAM_PORT_ANNOTATION = "resource.twingate.com/upstreamPort"
 UPSTREAM_TLS_ANNOTATION = "resource.twingate.com/upstreamTLS"
 REQUEST_HEADER_REWRITES_ANNOTATION = "resource.twingate.com/requestHeaderRewrites"
 

--- a/app/handlers/handlers_services.py
+++ b/app/handlers/handlers_services.py
@@ -36,6 +36,8 @@ GATEWAY_NAME_ANNOTATION = "resource.twingate.com/gatewayName"
 GATEWAY_NAMESPACE_ANNOTATION = "resource.twingate.com/gatewayNamespace"
 DOWNSTREAM_PORT_ANNOTATION = "resource.twingate.com/downstreamPort"
 UPSTREAM_PORT_ANNOTATION = "resource.twingate.com/upstreamPort"
+DOWNSTREAM_TLS_ANNOTATION = "resource.twingate.com/downstreamTLS"
+UPSTREAM_TLS_ANNOTATION = "resource.twingate.com/upstreamTLS"
 REQUEST_HEADER_REWRITES_ANNOTATION = "resource.twingate.com/requestHeaderRewrites"
 
 
@@ -123,6 +125,13 @@ def web_app_spec(service_body: Body, namespace: str) -> dict:
         "upstream": {"port": upstream},
     }
 
+    for key, annotation in (
+        ("downstream", DOWNSTREAM_TLS_ANNOTATION),
+        ("upstream", UPSTREAM_TLS_ANNOTATION),
+    ):
+        if tls := meta.annotations.get(annotation):
+            result[key]["tls"] = parse_bool_annotation(annotation, tls)
+
     if rewrites := meta.annotations.get(REQUEST_HEADER_REWRITES_ANNOTATION):
         invalid_msg = (
             f"{REQUEST_HEADER_REWRITES_ANNOTATION} annotation must be a JSON "
@@ -180,6 +189,15 @@ def parse_port_annotation(annotation: str, value: str) -> int:
     except ValueError:
         raise kopf.PermanentError(
             f"{annotation} annotation must be an integer."
+        ) from None
+
+
+def parse_bool_annotation(annotation: str, value: str) -> bool:
+    try:
+        return to_bool(value)
+    except ValueError:
+        raise kopf.PermanentError(
+            f"{annotation} annotation must be a boolean."
         ) from None
 
 

--- a/app/handlers/tests/test_handlers_services.py
+++ b/app/handlers/tests/test_handlers_services.py
@@ -321,6 +321,38 @@ class TestServiceToTwingateResource:
         ):
             service_to_twingate_resource(example_webapp_service_body, "default")
 
+    def test_webapp_resource_tls_annotations(self, example_webapp_service_body):
+        example_webapp_service_body.metadata["annotations"][
+            "resource.twingate.com/downstreamTLS"
+        ] = "true"
+        example_webapp_service_body.metadata["annotations"][
+            "resource.twingate.com/upstreamTLS"
+        ] = "false"
+
+        result = service_to_twingate_resource(example_webapp_service_body, "default")
+
+        assert result["spec"]["downstream"] == {"port": 80, "tls": True}
+        assert result["spec"]["upstream"] == {"port": 8080, "tls": False}
+
+    def test_webapp_resource_without_tls_annotations(self, example_webapp_service_body):
+        result = service_to_twingate_resource(example_webapp_service_body, "default")
+
+        assert result["spec"]["downstream"] == {"port": 80}
+        assert result["spec"]["upstream"] == {"port": 8080}
+
+    def test_webapp_resource_non_boolean_tls_annotation(
+        self, example_webapp_service_body
+    ):
+        example_webapp_service_body.metadata["annotations"][
+            "resource.twingate.com/downstreamTLS"
+        ] = "definitely"
+
+        with pytest.raises(
+            kopf.PermanentError,
+            match=r"resource.twingate.com/downstreamTLS annotation must be a boolean",
+        ):
+            service_to_twingate_resource(example_webapp_service_body, "default")
+
     def test_webapp_resource_request_header_rewrites(self, example_webapp_service_body):
         example_webapp_service_body.metadata["annotations"][
             "resource.twingate.com/requestHeaderRewrites"

--- a/app/tests/test_crds_resource.py
+++ b/app/tests/test_crds_resource.py
@@ -476,8 +476,8 @@ def test_web_app_resource_spec_to_graphql_arguments():
         address="webapp.default.cluster.local",
         type=ResourceType.WEB_APP,
         gateway_ref=_KubernetesObjectRef(name="my-gateway", namespace="twingate"),
-        downstream=ResourceDownstream(port=80),
-        upstream=ResourceUpstream(port=8080),
+        downstream=ResourceDownstream(port=443, tls=True),
+        upstream=ResourceUpstream(port=8080, tls=True),
         request_header_rewrites=[{"name": "X-Forwarded-Host", "value": "web-app.int"}],
     )
 
@@ -490,8 +490,8 @@ def test_web_app_resource_spec_to_graphql_arguments():
 
     resolve_mock.assert_called_once_with("twingategateways", "twingate", "my-gateway")
     assert graphql_arguments["gateway_id"] == "R2F0ZXdheTo5Nwo="
-    assert graphql_arguments["downstream"] == {"port": 80}
-    assert graphql_arguments["upstream"] == {"port": 8080}
+    assert graphql_arguments["downstream"] == {"port": 443, "tls": True}
+    assert graphql_arguments["upstream"] == {"port": 8080, "tls": True}
     assert graphql_arguments["request_header_rewrites"] == [
         {"key": "X-Forwarded-Host", "value": "web-app.int"}
     ]
@@ -517,6 +517,25 @@ def test_web_app_resource_spec_to_graphql_arguments_without_header_rewrites():
         )
 
     assert graphql_arguments["request_header_rewrites"] == []
+
+
+def test_web_app_resource_spec_to_graphql_arguments_defaults_tls_to_false():
+    resource_spec = ResourceSpec(
+        name="My WebApp Resource",
+        address="webapp.default.cluster.local",
+        type=ResourceType.WEB_APP,
+        gateway_ref=_KubernetesObjectRef(name="my-gateway"),
+        downstream=ResourceDownstream(port=80),
+        upstream=ResourceUpstream(port=8080),
+    )
+
+    with patch("app.crds.resolve_ref_to_twingate_id", return_value="gw-1"):
+        graphql_arguments = resource_spec.to_graphql_arguments(
+            labels={}, owner_namespace="default"
+        )
+
+    assert graphql_arguments["downstream"] == {"port": 80, "tls": False}
+    assert graphql_arguments["upstream"] == {"port": 8080, "tls": False}
 
 
 def test_resource_spec_to_graphql_arguments_when_sync_labels_disabled(

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -171,7 +171,8 @@ spec:
                       description: "The downstream port."
                     tls:
                       type: boolean
-                      description: "Whether TLS is enabled on the downstream (client-facing) connection. Defaults to false."
+                      default: false
+                      description: "Whether TLS is enabled on the downstream (client-facing) connection."
                 upstream:
                   type: object
                   required: ["port"]
@@ -184,7 +185,8 @@ spec:
                       description: "The upstream port."
                     tls:
                       type: boolean
-                      description: "Whether TLS is enabled on the upstream (target) connection. Defaults to false."
+                      default: false
+                      description: "Whether TLS is enabled on the upstream (target) connection."
                 requestHeaderRewrites:
                   type: array
                   description: "HTTP headers to rewrite on requests to the upstream of a WebApp Resource."

--- a/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
+++ b/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml
@@ -169,6 +169,9 @@ spec:
                       minimum: 1
                       maximum: 65535
                       description: "The downstream port."
+                    tls:
+                      type: boolean
+                      description: "Whether TLS is enabled on the downstream (client-facing) connection. Defaults to false."
                 upstream:
                   type: object
                   required: ["port"]
@@ -179,6 +182,9 @@ spec:
                       minimum: 1
                       maximum: 65535
                       description: "The upstream port."
+                    tls:
+                      type: boolean
+                      description: "Whether TLS is enabled on the upstream (target) connection. Defaults to false."
                 requestHeaderRewrites:
                   type: array
                   description: "HTTP headers to rewrite on requests to the upstream of a WebApp Resource."

--- a/examples/resource.yaml
+++ b/examples/resource.yaml
@@ -34,8 +34,10 @@ spec:
     name: example-gateway
   downstream:
     port: 80
+    tls: false
   upstream:
     port: 8080
+    tls: false
   requestHeaderRewrites:
     - name: Authorization
       value: "Bearer {{ jwt }}"

--- a/examples/service.yaml
+++ b/examples/service.yaml
@@ -35,6 +35,10 @@ metadata:
     # Optional. Upstream (target) port. Defaults to the Service's port when it
     # exposes exactly one; required if the Service exposes multiple ports.
     # resource.twingate.com/upstreamPort: "8080"
+    # Optional. Whether TLS is enabled on the downstream (client-facing) and upstream
+    # (target) connections. Both default to "false".
+    # resource.twingate.com/downstreamTLS: "true"
+    # resource.twingate.com/upstreamTLS: "true"
     # Optional. HTTP headers to rewrite on requests to the upstream (WebApp only).
     # resource.twingate.com/requestHeaderRewrites: '{"Host":"example.com"}'
     resource.twingate.com/alias: "webapp.internal"

--- a/tests_integration/test_crds_resource.py
+++ b/tests_integration/test_crds_resource.py
@@ -584,6 +584,57 @@ def test_web_app_resource_rejects_out_of_range_port(unique_resource_name):
     assert "spec.downstream.port" in stderr
 
 
+def test_web_app_resource_with_tls_accepted(unique_resource_name):
+    result = kubectl_create(
+        f"""
+        apiVersion: twingate.com/v1beta
+        kind: TwingateResource
+        metadata:
+          name: {unique_resource_name}
+        spec:
+          name: My WebApp Resource
+          address: "webapp.default.svc.cluster.local"
+          type: WebApp
+          gatewayRef:
+            name: my-gateway
+          downstream:
+            port: 443
+            tls: true
+          upstream:
+            port: 8080
+            tls: true
+        """
+    )
+    assert result.returncode == 0
+    kubectl_delete("tgr", unique_resource_name)
+
+
+def test_web_app_resource_rejects_non_boolean_tls(unique_resource_name):
+    with pytest.raises(subprocess.CalledProcessError) as ex:
+        kubectl_create(
+            f"""
+            apiVersion: twingate.com/v1beta
+            kind: TwingateResource
+            metadata:
+              name: {unique_resource_name}
+            spec:
+              name: My WebApp Resource
+              address: "webapp.default.svc.cluster.local"
+              type: WebApp
+              gatewayRef:
+                name: my-gateway
+              downstream:
+                port: 443
+                tls: "not-a-boolean"
+              upstream:
+                port: 8080
+            """
+        )
+
+    stderr = ex.value.stderr.decode()
+    assert "spec.downstream.tls" in stderr
+
+
 def test_web_app_resource_with_request_header_rewrites_accepted(unique_resource_name):
     result = kubectl_create(
         f"""

--- a/tests_integration/test_crds_resource.py
+++ b/tests_integration/test_crds_resource.py
@@ -628,11 +628,13 @@ def test_web_app_resource_rejects_non_boolean_tls(unique_resource_name):
                 tls: "not-a-boolean"
               upstream:
                 port: 8080
+                tls: "not-a-boolean"
             """
         )
 
     stderr = ex.value.stderr.decode()
     assert "spec.downstream.tls" in stderr
+    assert "spec.upstream.tls" in stderr
 
 
 def test_web_app_resource_with_request_header_rewrites_accepted(unique_resource_name):

--- a/tests_integration/test_service_flows.py
+++ b/tests_integration/test_service_flows.py
@@ -365,7 +365,9 @@ def test_service_flows_with_webapp_resource(run_kopf, random_name_generator):
             resource.twingate.com: "true"
             resource.twingate.com/type: "WebApp"
             resource.twingate.com/gatewayName: "{gw_name}"
-            resource.twingate.com/downstreamPort: "80"
+            resource.twingate.com/downstreamPort: "443"
+            resource.twingate.com/downstreamTLS: "true"
+            resource.twingate.com/upstreamTLS: "false"
             resource.twingate.com/alias: "webapp.internal"
             resource.twingate.com/requestHeaderRewrites: '{{"X-Forwarded-Host": "web-app.int", "Authorization": "Bearer {{{{ jwt }}}}"}}'
         spec:
@@ -406,8 +408,8 @@ def test_service_flows_with_webapp_resource(run_kopf, random_name_generator):
                 "address": f"{service_name}.default.svc.cluster.local",
                 "alias": "webapp.internal",
                 "gatewayRef": {"name": gw_name, "namespace": "default"},
-                "downstream": {"port": 80},
-                "upstream": {"port": 8080},
+                "downstream": {"port": 443, "tls": True},
+                "upstream": {"port": 8080, "tls": False},
                 "requestHeaderRewrites": [
                     {"name": "X-Forwarded-Host", "value": "web-app.int"},
                     {"name": "Authorization", "value": "Bearer {{ jwt }}"},

--- a/tests_integration/test_service_flows.py
+++ b/tests_integration/test_service_flows.py
@@ -558,8 +558,8 @@ def test_service_flows_resource_type_change(run_kopf, random_name_generator):
                 "namespace": "default",
             }
             # Both ports default to the Service's single TCP port.
-            assert tgr["spec"]["downstream"] == {"port": 8080}
-            assert tgr["spec"]["upstream"] == {"port": 8080}
+            assert tgr["spec"]["downstream"] == {"port": 8080, "tls": False}
+            assert tgr["spec"]["upstream"] == {"port": 8080, "tls": False}
             assert "protocols" not in tgr["spec"]
             web_app_resource_id = tgr["spec"]["id"]
 


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/kubernetes-operator/issues/1141

## Changes

Add TLS support for WebApp Resources on both the downstream (client-facing) and upstream (target) connections
- `TwingateResource` CRD: new `spec.downstream.tls` and `spec.upstream.tls` booleans, defaulting to `false` when omitted
- Service annotations `resource.twingate.com/downstreamTLS` and `resource.twingate.com/upstreamTLS` → map to the CRD fields

## Notes
🚧 **Do not merge before the feature is released on the Controller.**